### PR TITLE
Add new json fields for external monitor

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -14,9 +14,9 @@ import (
   "monitors": [
     {
       "id": "2cSZzK3XfmG",
-      "type": "passive",
-      "name": "connectivity",
-      "duration": 5
+      "type": "connectivity",
+      "scopes": [],
+      "excludeScopes": []
     },
     {
       "id"  : "2cSZzK3XfmG",
@@ -57,17 +57,19 @@ import (
 
 // Monitor information
 type Monitor struct {
-	ID            string   `json:"id,omitempty"`
-	Name          string   `json:"name,omitempty"`
-	Type          string   `json:"type,omitempty"`
-	Metric        string   `json:"metric,omitempty"`
-	Operator      string   `json:"operator,omitempty"`
-	Warning       float64  `json:"warning,omitempty"`
-	Critical      float64  `json:"critical,omitempty"`
-	Duration      uint64   `json:"duration,omitempty"`
-	URL           string   `json:"url,omitempty"`
-	Scopes        []string `json:"scopes,omitempty"`
-	ExcludeScopes []string `json:"excludeScopes,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	Metric           string   `json:"metric,omitempty"`
+	Operator         string   `json:"operator,omitempty"`
+	Warning          float64  `json:"warning,omitempty"`
+	Critical         float64  `json:"critical,omitempty"`
+	Duration         uint64   `json:"duration,omitempty"`
+	URL              string   `json:"url,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	Service          string   `json:"service,omitempty"`
+	MaxCheckAttempts float64  `json:"maxCheckAttempts,omitempty"`
+	ExcludeScopes    []string `json:"excludeScopes,omitempty"`
 }
 
 // FindMonitors find monitors

--- a/monitors.go
+++ b/monitors.go
@@ -57,19 +57,22 @@ import (
 
 // Monitor information
 type Monitor struct {
-	ID               string   `json:"id,omitempty"`
-	Name             string   `json:"name,omitempty"`
-	Type             string   `json:"type,omitempty"`
-	Metric           string   `json:"metric,omitempty"`
-	Operator         string   `json:"operator,omitempty"`
-	Warning          float64  `json:"warning,omitempty"`
-	Critical         float64  `json:"critical,omitempty"`
-	Duration         uint64   `json:"duration,omitempty"`
-	URL              string   `json:"url,omitempty"`
-	Scopes           []string `json:"scopes,omitempty"`
-	Service          string   `json:"service,omitempty"`
-	MaxCheckAttempts float64  `json:"maxCheckAttempts,omitempty"`
-	ExcludeScopes    []string `json:"excludeScopes,omitempty"`
+	ID                   string   `json:"id,omitempty"`
+	Name                 string   `json:"name,omitempty"`
+	Type                 string   `json:"type,omitempty"`
+	Metric               string   `json:"metric,omitempty"`
+	Operator             string   `json:"operator,omitempty"`
+	Warning              float64  `json:"warning,omitempty"`
+	Critical             float64  `json:"critical,omitempty"`
+	Duration             uint64   `json:"duration,omitempty"`
+	URL                  string   `json:"url,omitempty"`
+	Scopes               []string `json:"scopes,omitempty"`
+	Service              string   `json:"service,omitempty"`
+	MaxCheckAttempts     float64  `json:"maxCheckAttempts,omitempty"`
+	ExcludeScopes        []string `json:"excludeScopes,omitempty"`
+	ResponseTimeCritical float64  `json:"responseTimeCritical,omitempty"`
+	ResponseTimeWarning  float64  `json:"responseTimeWarning,omitempty"`
+	ResponseTimeDuration float64  `json:"responseTimeDuration,omitempty"`
 }
 
 // FindMonitors find monitors

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -17,10 +17,18 @@ func TestFindMonitors(t *testing.T) {
 		respJSON, _ := json.Marshal(map[string][]map[string]interface{}{
 			"monitors": []map[string]interface{}{
 				map[string]interface{}{
-					"id":       "2cSZzK3XfmG",
-					"type":     "passive",
-					"name":     "connectivity",
-					"duration": 5,
+					"id":            "2cSZzK3XfmG",
+					"type":          "connectivity",
+					"scopes":        []string{},
+					"excludeScopes": []string{},
+				},
+				map[string]interface{}{
+					"id":               "2c5bLca8d",
+					"type":             "external",
+					"name":             "testMonitorExternal",
+					"url":              "http://www.example.com/",
+					"maxCheckAttempts": 3,
+					"service":          "someService",
 				},
 			},
 		})
@@ -37,12 +45,15 @@ func TestFindMonitors(t *testing.T) {
 		t.Error("err shoud be nil but: ", err)
 	}
 
-	if monitors[0].Type != "passive" {
+	if monitors[0].Type != "connectivity" {
 		t.Error("request sends json including type but: ", monitors[0])
 	}
 
-	if monitors[0].Name != "connectivity" {
+	if monitors[1].Type != "external" {
 		t.Error("request sends json including name but: ", monitors[0])
 	}
 
+	if monitors[1].Service != "someService" {
+		t.Error("request sends json including name but: ", monitors[0])
+	}
 }


### PR DESCRIPTION
Recently `service` and `maxCheckAttempts` fields are added for json format of an external monitoring rule.

This pull request supports these two fields.