### PR TITLE
Improve error message when API result failed.

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -335,9 +335,5 @@ func (c *Client) RetireHost(id string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return errors.New("status code is not 200")
-	}
-
 	return nil
 }

--- a/hosts.go
+++ b/hosts.go
@@ -129,7 +129,7 @@ func (c *Client) FindHost(id string) (*Host, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (c *Client) FindHosts(param *FindHostsParam) ([]*Host, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (c *Client) CreateHost(param *CreateHostParam) (string, error) {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return "", err
 	}
@@ -256,7 +256,7 @@ func (c *Client) UpdateHost(hostID string, param *UpdateHostParam) (string, erro
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return "", err
 	}
@@ -298,7 +298,7 @@ func (c *Client) UpdateHostStatus(hostID string, status string) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return err
 	}
@@ -321,7 +321,7 @@ func (c *Client) RetireHost(id string) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return err
 	}

--- a/hosts.go
+++ b/hosts.go
@@ -129,10 +129,10 @@ func (c *Client) FindHost(id string) (*Host, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -176,10 +176,10 @@ func (c *Client) FindHosts(param *FindHostsParam) ([]*Host, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -216,10 +216,10 @@ func (c *Client) CreateHost(param *CreateHostParam) (string, error) {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -256,10 +256,10 @@ func (c *Client) UpdateHost(hostID string, param *UpdateHostParam) (string, erro
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -298,10 +298,10 @@ func (c *Client) UpdateHostStatus(hostID string, status string) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }
@@ -321,10 +321,10 @@ func (c *Client) RetireHost(id string) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }

--- a/hosts.go
+++ b/hosts.go
@@ -3,7 +3,6 @@ package mackerel
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -135,10 +134,6 @@ func (c *Client) FindHost(id string) (*Host, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return nil, errors.New("status code is not 200")
-	}
-
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -185,10 +180,6 @@ func (c *Client) FindHosts(param *FindHostsParam) ([]*Host, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, errors.New("status code is not 200")
-	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/mackerel.go
+++ b/mackerel.go
@@ -1,7 +1,7 @@
 package mackerel
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -89,7 +89,7 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 		}
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
+		return nil, fmt.Errorf("API result failed: %s", resp.Status)
 	}
 	return resp, nil
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -1,6 +1,7 @@
 package mackerel
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -86,6 +87,9 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 		if err == nil {
 			log.Printf("%s", dump)
 		}
+	}
+	if resp.StatusCode != 200 {
+		return nil, errors.New(resp.Status)
 	}
 	return resp, nil
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -94,8 +94,7 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 	return resp, nil
 }
 
-// CloseReponse clos body stream if response exists.
-func (c *Client) CloseReponse(resp *http.Response) {
+func closeResponse(resp *http.Response) {
 	if resp != nil {
 		resp.Body.Close()
 	}

--- a/mackerel.go
+++ b/mackerel.go
@@ -88,8 +88,8 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 			log.Printf("%s", dump)
 		}
 	}
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("API result failed: %s", resp.Status)
+	if resp.StatusCode < 200 && resp.StatusCode > 299 {
+		return resp, fmt.Errorf("API result failed: %s", resp.Status)
 	}
 	return resp, nil
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -93,3 +93,10 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 	}
 	return resp, nil
 }
+
+// CloseReponse clos body stream if response exists.
+func (c *Client) CloseReponse(resp *http.Response) {
+	if resp != nil {
+		resp.Body.Close()
+	}
+}

--- a/mackerel.go
+++ b/mackerel.go
@@ -88,7 +88,7 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 			log.Printf("%s", dump)
 		}
 	}
-	if resp.StatusCode < 200 && resp.StatusCode > 299 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return resp, fmt.Errorf("API result failed: %s", resp.Status)
 	}
 	return resp, nil

--- a/metrics.go
+++ b/metrics.go
@@ -48,10 +48,7 @@ func (c *Client) PostHostMetricValues(metricValues [](*HostMetricValue)) error {
 	if err != nil {
 		return err
 	}
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("API result failed: %s", resp.Status)
-	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -91,10 +88,7 @@ func (c *Client) PostServiceMetricValues(serviceName string, metricValues [](*Me
 	if err != nil {
 		return err
 	}
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("API result failed: %s", resp.Status)
-	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -118,10 +112,6 @@ func (c *Client) FetchLatestMetricValues(hostIDs []string, metricNames []string)
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("status code is not 200")
-	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -45,7 +45,7 @@ func (c *Client) PostHostMetricValues(metricValues [](*HostMetricValue)) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (c *Client) PostServiceMetricValues(serviceName string, metricValues [](*Me
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (c *Client) FetchLatestMetricValues(hostIDs []string, metricNames []string)
 		return nil, err
 	}
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -45,10 +45,10 @@ func (c *Client) PostHostMetricValues(metricValues [](*HostMetricValue)) error {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }
@@ -85,10 +85,10 @@ func (c *Client) PostServiceMetricValues(serviceName string, metricValues [](*Me
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }
@@ -108,10 +108,10 @@ func (c *Client) FetchLatestMetricValues(hostIDs []string, metricNames []string)
 		return nil, err
 	}
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/monitors.go
+++ b/monitors.go
@@ -81,10 +81,10 @@ func (c *Client) FindMonitors() ([]*Monitor, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -121,10 +121,10 @@ func (c *Client) CreateMonitor(param *Monitor) (*Monitor, error) {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -159,10 +159,10 @@ func (c *Client) UpdateMonitor(monitorID string, param *Monitor) (*Monitor, erro
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -192,10 +192,10 @@ func (c *Client) DeleteMonitor(monitorID string) (*Monitor, error) {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
+	defer c.CloseReponse(resp)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/monitors.go
+++ b/monitors.go
@@ -81,7 +81,7 @@ func (c *Client) FindMonitors() ([]*Monitor, error) {
 		return nil, err
 	}
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (c *Client) UpdateMonitor(monitorID string, param *Monitor) (*Monitor, erro
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (c *Client) DeleteMonitor(monitorID string) (*Monitor, error) {
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := c.Request(req)
-	defer c.CloseReponse(resp)
+	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/monitors.go
+++ b/monitors.go
@@ -3,7 +3,6 @@ package mackerel
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -86,10 +85,6 @@ func (c *Client) FindMonitors() ([]*Monitor, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, errors.New("status code is not 200")
-	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
* Check status code at `func (c *Client) Request(req *http.Request) (resp *http.Response, err error)`
* Delete unused error handling codes.

ex) using read only API key.

before

```sh
mkr update -st working 2tZ7W9JYyqQ
     updated 2tZ7W9JYyqQ
```

after

```sh
mkr update -st working 2tZ7W9JYyqQ
     error API result failed: 403 Forbidden
```