### PR TITLE
Upgrade Go version to 1.6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.4
+- 1.6
 env: PATH=/home/travis/gopath/bin:$PATH
 script:
   - make test


### PR DESCRIPTION
When we continue to use Go 1.4.x, the test fails on `imports go/types: unrecognized import path "go/types"`. I'm not familiar with the actual reason why the build fails with this message, but upgrading the Go version fixes the issue. This is a library and Travis is used for testing, not for generating a binary. Anyway, newer the better.