### PR TITLE
Change the type of metadata to interface{}

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -57,8 +57,8 @@ type Memory map[string]string
 
 // Cloud cloud
 type Cloud struct {
-	Provider string                 `json:"provider,omitempty"`
-	MetaData map[string]interface{} `json:"metadata,omitempty"`
+	Provider string      `json:"provider,omitempty"`
+	MetaData interface{} `json:"metadata,omitempty"`
 }
 
 // Interface network interface


### PR DESCRIPTION
#17 
I thought `map[string]interface{}` is accurate. But it's not useful when we define our own jsonner to custom struct.