### PR TITLE
Ensure path part of BaseURL is ignored

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultBaseURL    = "https://mackerel.io/api/v0"
+	defaultBaseURL    = "https://mackerel.io/"
 	defaultUserAgent  = "mackerel-client-go"
 	apiRequestTimeout = 30 * time.Second
 )

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -25,8 +25,8 @@ func TestRequest(t *testing.T) {
 }
 
 func TestUrlFor(t *testing.T) {
-	client, _ := NewClientWithOptions("dummy-key", "https://mymackerel.io/with/ignored/path", false)
-	xURL := "https://mymackerel.io/some/super/endpoint"
+	client, _ := NewClientWithOptions("dummy-key", "https://example.com/with/ignored/path", false)
+	xURL := "https://example.com/some/super/endpoint"
 	if url := client.urlFor("/some/super/endpoint").String(); url != xURL {
 		t.Errorf("urlFor should be '%s' but %s", xURL, url)
 	}

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -24,6 +24,14 @@ func TestRequest(t *testing.T) {
 	client.Request(req)
 }
 
+func TestUrlFor(t *testing.T) {
+	client, _ := NewClientWithOptions("dummy-key", "https://mymackerel.io/with/ignored/path", false)
+	xURL := "https://mymackerel.io/some/super/endpoint"
+	if url := client.urlFor("/some/super/endpoint").String(); url != xURL {
+		t.Errorf("urlFor should be '%s' but %s", xURL, url)
+	}
+}
+
 func TestBuildReq(t *testing.T) {
 	cl := NewClient("dummy-key")
 	xVer := "1.0.1"


### PR DESCRIPTION
Current implementation, Pass part of `mackerel.Client.BaseURL` is ignored.
I think this is OK, but `mackerel.defaultBaseURL` includes path `/api/v0` and it is very confusing.
So how about removing `/api/v0` from `defaultBaseURL`?