### PR TITLE
Add convenient methods, MonitorID() and MonitorName() to the monitor interface

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -68,8 +68,9 @@ import (
 // monitorI represents interface to which each monitor type must confirm to.
 // TODO(haya14busa): remove trailing `I` in the name after migrating interface.
 type monitorI interface {
-	// MonitorType() must return monitor type.
 	MonitorType() string
+	MonitorID() string
+	MonitorName() string
 }
 
 const (
@@ -102,9 +103,9 @@ type MonitorConnectivity struct {
 }
 
 // MonitorType returns monitor type.
-func (m *MonitorConnectivity) MonitorType() string {
-	return monitorTypeConnectivity
-}
+func (m *MonitorConnectivity) MonitorType() string { return monitorTypeConnectivity }
+func (m *MonitorConnectivity) MonitorName() string { return m.Name }
+func (m *MonitorConnectivity) MonitorID() string   { return m.ID }
 
 // MonitorHostMetric represents host metric monitor.
 type MonitorHostMetric struct {
@@ -125,9 +126,9 @@ type MonitorHostMetric struct {
 }
 
 // MonitorType returns monitor type.
-func (m *MonitorHostMetric) MonitorType() string {
-	return monitorTypeHostMeric
-}
+func (m *MonitorHostMetric) MonitorType() string { return monitorTypeHostMeric }
+func (m *MonitorHostMetric) MonitorName() string { return m.Name }
+func (m *MonitorHostMetric) MonitorID() string   { return m.ID }
 
 // MonitorServiceMetric represents service metric monitor.
 type MonitorServiceMetric struct {
@@ -146,9 +147,9 @@ type MonitorServiceMetric struct {
 }
 
 // MonitorType returns monitor type.
-func (m *MonitorServiceMetric) MonitorType() string {
-	return monitorTypeServiceMetric
-}
+func (m *MonitorServiceMetric) MonitorType() string { return monitorTypeServiceMetric }
+func (m *MonitorServiceMetric) MonitorName() string { return m.Name }
+func (m *MonitorServiceMetric) MonitorID() string   { return m.ID }
 
 // MonitorExternalHTTP represents external HTTP monitor.
 type MonitorExternalHTTP struct {
@@ -170,9 +171,9 @@ type MonitorExternalHTTP struct {
 }
 
 // MonitorType returns monitor type.
-func (m *MonitorExternalHTTP) MonitorType() string {
-	return monitorTypeExternalHTTP
-}
+func (m *MonitorExternalHTTP) MonitorType() string { return monitorTypeExternalHTTP }
+func (m *MonitorExternalHTTP) MonitorName() string { return m.Name }
+func (m *MonitorExternalHTTP) MonitorID() string   { return m.ID }
 
 // MonitorExpression represents expression monitor.
 type MonitorExpression struct {
@@ -189,9 +190,9 @@ type MonitorExpression struct {
 }
 
 // MonitorType returns monitor type.
-func (m *MonitorExpression) MonitorType() string {
-	return monitorTypeExpression
-}
+func (m *MonitorExpression) MonitorType() string { return monitorTypeExpression }
+func (m *MonitorExpression) MonitorName() string { return m.Name }
+func (m *MonitorExpression) MonitorID() string   { return m.ID }
 
 // Monitor information
 type Monitor struct {

--- a/monitors.go
+++ b/monitors.go
@@ -104,8 +104,12 @@ type MonitorConnectivity struct {
 
 // MonitorType returns monitor type.
 func (m *MonitorConnectivity) MonitorType() string { return monitorTypeConnectivity }
+
+// MonitorName returns monitor name.
 func (m *MonitorConnectivity) MonitorName() string { return m.Name }
-func (m *MonitorConnectivity) MonitorID() string   { return m.ID }
+
+// MonitorID returns monitor id.
+func (m *MonitorConnectivity) MonitorID() string { return m.ID }
 
 // MonitorHostMetric represents host metric monitor.
 type MonitorHostMetric struct {
@@ -127,8 +131,12 @@ type MonitorHostMetric struct {
 
 // MonitorType returns monitor type.
 func (m *MonitorHostMetric) MonitorType() string { return monitorTypeHostMeric }
+
+// MonitorName returns monitor name.
 func (m *MonitorHostMetric) MonitorName() string { return m.Name }
-func (m *MonitorHostMetric) MonitorID() string   { return m.ID }
+
+// MonitorID returns monitor id.
+func (m *MonitorHostMetric) MonitorID() string { return m.ID }
 
 // MonitorServiceMetric represents service metric monitor.
 type MonitorServiceMetric struct {
@@ -148,8 +156,12 @@ type MonitorServiceMetric struct {
 
 // MonitorType returns monitor type.
 func (m *MonitorServiceMetric) MonitorType() string { return monitorTypeServiceMetric }
+
+// MonitorName returns monitor name.
 func (m *MonitorServiceMetric) MonitorName() string { return m.Name }
-func (m *MonitorServiceMetric) MonitorID() string   { return m.ID }
+
+// MonitorID returns monitor id.
+func (m *MonitorServiceMetric) MonitorID() string { return m.ID }
 
 // MonitorExternalHTTP represents external HTTP monitor.
 type MonitorExternalHTTP struct {
@@ -172,8 +184,12 @@ type MonitorExternalHTTP struct {
 
 // MonitorType returns monitor type.
 func (m *MonitorExternalHTTP) MonitorType() string { return monitorTypeExternalHTTP }
+
+// MonitorName returns monitor name.
 func (m *MonitorExternalHTTP) MonitorName() string { return m.Name }
-func (m *MonitorExternalHTTP) MonitorID() string   { return m.ID }
+
+// MonitorID returns monitor id.
+func (m *MonitorExternalHTTP) MonitorID() string { return m.ID }
 
 // MonitorExpression represents expression monitor.
 type MonitorExpression struct {
@@ -191,8 +207,12 @@ type MonitorExpression struct {
 
 // MonitorType returns monitor type.
 func (m *MonitorExpression) MonitorType() string { return monitorTypeExpression }
+
+// MonitorName returns monitor name.
 func (m *MonitorExpression) MonitorName() string { return m.Name }
-func (m *MonitorExpression) MonitorID() string   { return m.ID }
+
+// MonitorID returns monitor id.
+func (m *MonitorExpression) MonitorID() string { return m.ID }
 
 // Monitor information
 type Monitor struct {


### PR DESCRIPTION
We often want to access monitor ID and name fields without type assertion to each monitor type, so this p-r added convenient method to access them.

There are other common fields in monitor type, but I think id and name (and type) should be enough.

ref: Refactoring Monitor type #30
