### PR TITLE
Refactoring Monitor type(1.5): require internal isMonitor() method for Monitor interface

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -71,6 +71,8 @@ type monitorI interface {
 	MonitorType() string
 	MonitorID() string
 	MonitorName() string
+
+	isMonitor()
 }
 
 const (
@@ -89,6 +91,15 @@ var (
 	_ monitorI = (*MonitorExternalHTTP)(nil)
 	_ monitorI = (*MonitorExpression)(nil)
 )
+
+// Ensure only monitor types defined in this package can be assigned to the
+// Monitor interface.
+//
+func (m *MonitorConnectivity) isMonitor()  {}
+func (m *MonitorHostMetric) isMonitor()    {}
+func (m *MonitorServiceMetric) isMonitor() {}
+func (m *MonitorExternalHTTP) isMonitor()  {}
+func (m *MonitorExpression) isMonitor()    {}
 
 // MonitorConnectivity represents connectivity monitor.
 type MonitorConnectivity struct {


### PR DESCRIPTION
ref: #30

This prevents custom monitor type defined in external packages confirm
the Monitor interface.

You can find this idiom in go/ast package. https://github.com/golang/go/blob/964639cc338db650ccadeafb7424bc8ebb2c0f6c/src/go/ast/ast.go#L488-L489
FWIW, You can also find it in generated code by protocol buffer. (oneof keyword)

https://gist.github.com/haya14busa/1096006fd4909c6447c8b5f79eb8d08f

```proto
message Monitor {
  // ...
  oneof body {
    Connectivity connectivity = 4;
    HostMetric host_metric = 5;
  }

}

message Connectivity {
  // ...
}

message HostMetric {
  // ...
}
```

```go
// ....
type isMonitor_Body interface {
	isMonitor_Body()
}

type Monitor_Connectivity struct {
	Connectivity *Connectivity `protobuf:"bytes,4,opt,name=connectivity,oneof"`
}
type Monitor_HostMetric struct {
	HostMetric *HostMetric `protobuf:"bytes,5,opt,name=host_metric,json=hostMetric,oneof"`
}

func (*Monitor_Connectivity) isMonitor_Body() {}
func (*Monitor_HostMetric) isMonitor_Body()   {}
// ....
```

#### Sample

(This sample assumes that Monitor interface is public, which is not public in master branch right now.)

```go
package main

import (
	"github.com/mackerelio/mackerel-client-go"
)

type MyMonitor struct{}

func (m *MyMonitor) MonitorType() string { return "" }
func (m *MyMonitor) MonitorID() string   { return "" }
func (m *MyMonitor) MonitorName() string { return "" }
func (m *MyMonitor) isMonitor()          {}

var _ mackerel.Monitor = &MyMonitor{}

// =>
// cannot use MyMonitor literal (type *MyMonitor) as type mackerel.Monitor in assignment:
// 	*MyMonitor does not implement mackerel.Monitor (missing mackerel.isMonitor method)
// 		have isMonitor()
// 		want mackerel.isMonitor()
```
