### PR TITLE
Support SkipCertificateVerification for external http monitors

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -61,7 +61,8 @@ import (
       "responseTimeDuration": 5,
       "certificationExpirationCritical": 15,
       "certificationExpirationWarning": 30,
-      "containsString": "Example"
+      "containsString": "Example",
+      "skipCertificateVerification": true
     }
   ]
 }
@@ -192,6 +193,7 @@ type MonitorExternalHTTP struct {
 	ContainsString                  string  `json:"containsString,omitempty"`
 	CertificationExpirationCritical uint64  `json:"certificationExpirationCritical,omitempty"`
 	CertificationExpirationWarning  uint64  `json:"certificationExpirationWarning,omitempty"`
+	SkipCertificateVerification     bool    `json:"skipCertificateVerification,omitempty"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -40,6 +40,7 @@ func TestFindMonitors(t *testing.T) {
 					"certificationExpirationCritical": 15,
 					"certificationExpirationWarning":  30,
 					"containsString":                  "Foo Bar Baz",
+					"skipCertificateVerification":     true,
 				},
 				{
 					"id":         "2DujfcR2kA9",
@@ -106,6 +107,10 @@ func TestFindMonitors(t *testing.T) {
 
 		if m.ContainsString != "Foo Bar Baz" {
 			t.Error("request sends json including containsString but: ", m)
+		}
+
+		if m.SkipCertificateVerification != true {
+			t.Error("request sends json including skipCertificateVerification but: ", m)
 		}
 	}
 
@@ -232,6 +237,7 @@ var wantMonitors = []Monitor{
 		ContainsString:                  "",
 		CertificationExpirationCritical: 0,
 		CertificationExpirationWarning:  0,
+		SkipCertificateVerification:     false,
 	},
 	&MonitorExpression{
 		ID:                   "2cSZzK3XfmE",


### PR DESCRIPTION
This pull request add support for the `skipCertificateVerification` field of external http monitors. I confirmed this pull request by building mkr and the monitors subcommand works expectedly on *pulling*, *diffing* and *updating* external http monitors.