### PR TITLE
Support "headers" field for external http monitors 

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -62,7 +62,10 @@ import (
       "certificationExpirationCritical": 15,
       "certificationExpirationWarning": 30,
       "containsString": "Example",
-      "skipCertificateVerification": true
+      "skipCertificateVerification": true,
+      "headers": [
+        { "name": "Cache-Control", "value": "no-cache"}
+      ]
     }
   ]
 }
@@ -194,6 +197,17 @@ type MonitorExternalHTTP struct {
 	CertificationExpirationCritical uint64  `json:"certificationExpirationCritical,omitempty"`
 	CertificationExpirationWarning  uint64  `json:"certificationExpirationWarning,omitempty"`
 	SkipCertificateVerification     bool    `json:"skipCertificateVerification,omitempty"`
+	// Empty list of headers and nil are different. You have to specify empty
+	// list as headers explicitly if you want to remove all headers instead of
+	// using nil.
+	Headers []HeaderField `json:"headers"`
+}
+
+// HeaderField represents key-value pairs in an HTTP header for external http
+// monitoring.
+type HeaderField struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -276,6 +276,12 @@ var wantMonitors = []Monitor{
 		CertificationExpirationCritical: 0,
 		CertificationExpirationWarning:  0,
 		SkipCertificateVerification:     false,
+		Headers: []HeaderField{
+			{
+				Name:  "Cache-Control",
+				Value: "no-cache",
+			},
+		},
 	},
 	&MonitorExpression{
 		ID:                   "2cSZzK3XfmE",

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -129,6 +129,37 @@ func TestFindMonitors(t *testing.T) {
 	}
 }
 
+// ensure that it supports `"headers":[]` and headers must be nil by default.
+func TestMonitorExternalHTTP_headers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *MonitorExternalHTTP
+		want string
+	}{
+		{
+			name: "default",
+			in:   &MonitorExternalHTTP{},
+			want: `{"headers":null}`,
+		},
+		{
+			name: "empty list",
+			in:   &MonitorExternalHTTP{Headers: []HeaderField{}},
+			want: `{"headers":[]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		b, err := json.Marshal(tt.in)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got := string(b); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 const monitorsjson = `
 {
   "monitors": [

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -41,6 +41,9 @@ func TestFindMonitors(t *testing.T) {
 					"certificationExpirationWarning":  30,
 					"containsString":                  "Foo Bar Baz",
 					"skipCertificateVerification":     true,
+					"headers": []map[string]interface{}{
+						{"name": "Cache-Control", "value": "no-cache"},
+					},
 				},
 				{
 					"id":         "2DujfcR2kA9",
@@ -111,6 +114,10 @@ func TestFindMonitors(t *testing.T) {
 
 		if m.SkipCertificateVerification != true {
 			t.Error("request sends json including skipCertificateVerification but: ", m)
+		}
+
+		if !reflect.DeepEqual(m.Headers, []HeaderField{{Name: "Cache-Control", Value: "no-cache"}}) {
+			t.Error("request sends json including headers but: ", m)
 		}
 	}
 


### PR DESCRIPTION
You can confirm it works in the same way with #36.

Note that "headers" field tag doesn't have `omitempty` to handle compatibility issues.