### PR TITLE
[mackerelio/mkr] Accept a value of 0 for warning and critical

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -137,8 +137,8 @@ type MonitorHostMetric struct {
 
 	Metric   string  `json:"metric,omitempty"`
 	Operator string  `json:"operator,omitempty"`
-	Warning  float64 `json:"warning,omitempty"`
-	Critical float64 `json:"critical,omitempty"`
+	Warning  float64 `json:"warning"`
+	Critical float64 `json:"critical"`
 	Duration uint64  `json:"duration,omitempty"`
 
 	Scopes        []string `json:"scopes,omitempty"`
@@ -165,8 +165,8 @@ type MonitorServiceMetric struct {
 	Service  string  `json:"service,omitempty"`
 	Metric   string  `json:"metric,omitempty"`
 	Operator string  `json:"operator,omitempty"`
-	Warning  float64 `json:"warning,omitempty"`
-	Critical float64 `json:"critical,omitempty"`
+	Warning  float64 `json:"warning"`
+	Critical float64 `json:"critical"`
 	Duration uint64  `json:"duration,omitempty"`
 }
 
@@ -229,8 +229,8 @@ type MonitorExpression struct {
 
 	Expression string  `json:"expression,omitempty"`
 	Operator   string  `json:"operator,omitempty"`
-	Warning    float64 `json:"warning,omitempty"`
-	Critical   float64 `json:"critical,omitempty"`
+	Warning    float64 `json:"warning"`
+	Critical   float64 `json:"critical"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -325,3 +325,49 @@ func decodeMonitorsJSON(t testing.TB) []Monitor {
 	}
 	return ms
 }
+
+var monitorsToBeEncoded = []Monitor{
+	&MonitorHostMetric{
+		ID:       "2cSZzK3XfmB",
+		Warning:  0.000000,
+		Critical: 400000.000000,
+	},
+	&MonitorServiceMetric{
+		ID:       "2cSZzK3XfmC",
+		Warning:  50.000000,
+		Critical: 0.000000,
+	},
+	&MonitorExpression{
+		ID:       "2cSZzK3XfmE",
+		Warning:  0.000000,
+		Critical: 0.000000,
+	},
+}
+
+func TestEncodeMonitor(t *testing.T) {
+	b, err := json.MarshalIndent(monitorsToBeEncoded, "", "    ")
+	if err != nil {
+		t.Error("err shoud be nil but: ", err)
+	}
+
+	want := `[
+    {
+        "id": "2cSZzK3XfmB",
+        "warning": 0,
+        "critical": 400000
+    },
+    {
+        "id": "2cSZzK3XfmC",
+        "warning": 50,
+        "critical": 0
+    },
+    {
+        "id": "2cSZzK3XfmE",
+        "warning": 0,
+        "critical": 0
+    }
+]`
+	if got := string(b); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Mackerel Web UI ( ex. https://mackerel.io/orgs/hogehoge/monitors ) accept rules of which either (or both) warning and critical are 0. And these rules are reasonable.

But [mkr](https://github.com/mackerelio/mkr/releases/tag/v0.13.0) can not accept these rules. 

```
# 1. Changed a warning to 0 from UI
$ mkr monitors diff
Summary: 1 modify, 0 append, 0 remove

 {
   "critical": 1,
   "duration": 1,
   "metric": "custom.hogehoge-dlv-elb-status-count.SpilloverCount",
   "name": "hogehoge - dlv-elb-status-count.SpilloverCount",
   "notificationInterval": 10,
   "operator": ">",
   "service": "hogehoge",
   "type": "service",
-  "warning": 0
+  "warning": 0.1
 },

# 2. Pull.
$ mkr monitors pull
      info Monitor rules are saved to 'monitors.json' (360 rules).
/m/m/Mackerel ❯❯❯ git diff
diff --git a/Mackerel/monitors.json b/Mackerel/monitors.json
index 58b7505..05e0aa3 100644
--- a/Mackerel/monitors.json
+++ b/Mackerel/monitors.json
@@ -2173,7 +2173,7 @@
             "service": "hogehoge",
             "metric": "custom.hogehoge-dlv-elb-status-count.SpilloverCount",
             "operator": ">",
-            "warning": 0.1,
+            "warning": 0,
             "critical": 1,
             "duration": 1
         },

# Changed a monitors.json to work `mkr monitors push`
$ git diff
diff --git a/Mackerel/monitors.json b/Mackerel/monitors.json
index 58b7505..48cf6f5 100644
--- a/Mackerel/monitors.json
+++ b/Mackerel/monitors.json
@@ -2173,9 +2173,9 @@
             "service": "hogehoge",
             "metric": "custom.hogehoge-dlv-elb-status-count.SpilloverCount",
             "operator": ">",
-            "warning": 0.1,
+            "warning": 0,
             "critical": 1,
-            "duration": 1
+            "duration": 2
         },
         {
             "id": "2yyf3Pcpnwq",

# Push, 400 Bad Request because warning is omitted
$ mkr monitors push
      info Update a rule.
 {
   "id": "2Sh2b6WrppE",
   "name": "hogehoge - custom.hogehoge-dlv-elb-status-count.SpilloverCount",
   "type": "service",
   "metric": "custom.hogehoge-dlv-elb-status-count.SpilloverCount",
   "operator": ">",
   "critical": 1,
   "duration": 2,
   "service": "hogehoge",
   "notificationInterval": 10
 },
     error API result failed: 400 Bad Request
```

I want mkr to work well in this situation.

[NOTES] I don't grasp extent of impact for other libraries and users well.