### PR TITLE
Add IPv[46]Addresses property to Interface

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -64,9 +64,11 @@ type Cloud struct {
 
 // Interface network interface
 type Interface struct {
-	Name       string `json:"name,omitempty"`
-	IPAddress  string `json:"ipAddress,omitempty"`
-	MacAddress string `json:"macAddress,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	IPAddress     string   `json:"ipAddress,omitempty"`
+	IPv4Addresses []string `json:"ipv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"ipv6Addresses,omitempty"`
+	MacAddress    string   `json:"macAddress,omitempty"`
 }
 
 // FindHostsParam parameters for FindHosts

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -44,6 +44,15 @@ func TestFindHost(t *testing.T) {
 				"status": "working",
 				"memo":   "hello",
 				"roles":  map[string][]string{"My-Service": {"db-master", "db-slave"}},
+				"interfaces": []map[string]interface{}{
+					{
+						"name":          "lo0",
+						"ipAddress":     "127.0.0.1",
+						"ipv4Addresses": []string{"127.0.0.1"},
+						"ipv6Addresses": []string{"fe80::1"},
+						"macAddress":    "02:02:02:02:02:02",
+					},
+				},
 			},
 		})
 
@@ -67,6 +76,15 @@ func TestFindHost(t *testing.T) {
 		t.Errorf("Wrong data for roles: %v", host.Roles)
 	}
 
+	if len(host.Interfaces) == 1 && reflect.DeepEqual(host.Interfaces[0], Interface{
+		Name:          "lo0",
+		IPAddress:     "127.0.0.1",
+		IPv4Addresses: []string{"127.0.0.1"},
+		IPv6Addresses: []string{"fe80::1"},
+		MacAddress:    "02:02:02:02:02:02",
+	}) != true {
+		t.Errorf("Wrong data for interfaces: %v", host.Interfaces)
+	}
 }
 
 func TestFindHosts(t *testing.T) {


### PR DESCRIPTION
Some Mackerel API yields `Interface` object. On document, it has `ipv4Addresses` and `ipv6Addresses` property, but this library does not provide these properties. This PR adds these properties.

Thank you.