### PR TITLE
Implement Host#IPAddressesAll and mark Host#IPAddresses as deprecated

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -122,6 +122,8 @@ func (h *Host) DateStringFromCreatedAt() string {
 }
 
 // IPAddresses returns ipaddresses
+//
+// Deprecated: use Host#IPAddressesAll instead.
 func (h *Host) IPAddresses() map[string]string {
 	if len(h.Interfaces) < 1 {
 		return nil
@@ -132,6 +134,26 @@ func (h *Host) IPAddresses() map[string]string {
 		ipAddresses[iface.Name] = iface.IPAddress
 	}
 	return ipAddresses
+}
+
+// IPAddressesAll returns all ipaddresses
+//
+// Its result is a map of a slice of string. This key means interface name
+// and this value means ipaddresses bound to this interface.
+func (h *Host) IPAddressesAll() map[string][]string {
+	if len(h.Interfaces) < 1 {
+		return nil
+	}
+
+	ipAddressesAll := make(map[string][]string, 0)
+	for _, iface := range h.Interfaces {
+		ipAddresses := make([]string, 0, len(iface.IPv4Addresses)+len(iface.IPv6Addresses))
+		ipAddresses = append(ipAddresses, iface.IPv4Addresses...)
+		ipAddresses = append(ipAddresses, iface.IPv6Addresses...)
+		ipAddressesAll[iface.Name] = ipAddresses
+	}
+
+	return ipAddressesAll
 }
 
 // FindHost find the host

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -27,6 +27,32 @@ func TestGetRoleFullnames(t *testing.T) {
 	}
 }
 
+func TestIPAddressesAll(t *testing.T) {
+	host := &Host{
+		Interfaces: []Interface{
+			{
+				Name:          "lo0",
+				IPv4Addresses: []string{"127.0.0.1"},
+				IPv6Addresses: []string{"::1", "fe80::1"},
+			},
+			{
+				Name:          "en0",
+				IPv4Addresses: []string{"192.168.42.42"},
+				IPv6Addresses: []string{},
+			},
+		},
+	}
+
+	ipAddressesAll := host.IPAddressesAll()
+
+	if !reflect.DeepEqual(ipAddressesAll, map[string][]string{
+		"lo0": {"127.0.0.1", "::1", "fe80::1"},
+		"en0": {"192.168.42.42"},
+	}) {
+		t.Errorf("unexpected IPAddressesAll result: %#v", ipAddressesAll)
+	}
+}
+
 func TestFindHost(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/api/v0/hosts/9rxGOHfVF8F" {


### PR DESCRIPTION
See https://github.com/mackerelio/mackerel-client-go/pull/47#issuecomment-327796756