### PR TITLE
Test with both Go 1.6 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
 - 1.6
+- 1.9
 env: PATH=/home/travis/gopath/bin:$PATH
 script:
   - make test


### PR DESCRIPTION
There's no obvious policy which version to support, but (as long as ci passes) testing with both versions is not bad thing.