### PR TITLE
Add support of maxCheckAttempts for host metric and service metric monitors

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -34,6 +34,7 @@ import (
       "excludeScopes": [
         "SomeService: db-slave-backup"
       ],
+      "maxCheckAttempts": 1,
       "notificationInterval": 60
     },
     {
@@ -46,7 +47,8 @@ import (
       "metric": "custom.access_num.4xx_count",
       "operator": ">",
       "warning": 50.0,
-      "critical": 100.0
+      "critical": 100.0,
+      "maxCheckAttempts": 1
     },
     {
       "id"  : "2cSZzK3XfmG",

--- a/monitors.go
+++ b/monitors.go
@@ -139,11 +139,12 @@ type MonitorHostMetric struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Metric   string  `json:"metric,omitempty"`
-	Operator string  `json:"operator,omitempty"`
-	Warning  float64 `json:"warning"`
-	Critical float64 `json:"critical"`
-	Duration uint64  `json:"duration,omitempty"`
+	Metric           string  `json:"metric,omitempty"`
+	Operator         string  `json:"operator,omitempty"`
+	Warning          float64 `json:"warning"`
+	Critical         float64 `json:"critical"`
+	Duration         uint64  `json:"duration,omitempty"`
+	MaxCheckAttempts uint64  `json:"maxCheckAttempts,omitempty"`
 
 	Scopes        []string `json:"scopes,omitempty"`
 	ExcludeScopes []string `json:"excludeScopes,omitempty"`
@@ -167,12 +168,13 @@ type MonitorServiceMetric struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Service  string  `json:"service,omitempty"`
-	Metric   string  `json:"metric,omitempty"`
-	Operator string  `json:"operator,omitempty"`
-	Warning  float64 `json:"warning"`
-	Critical float64 `json:"critical"`
-	Duration uint64  `json:"duration,omitempty"`
+	Service          string  `json:"service,omitempty"`
+	Metric           string  `json:"metric,omitempty"`
+	Operator         string  `json:"operator,omitempty"`
+	Warning          float64 `json:"warning"`
+	Critical         float64 `json:"critical"`
+	Duration         uint64  `json:"duration,omitempty"`
+	MaxCheckAttempts uint64  `json:"maxCheckAttempts,omitempty"`
 }
 
 // MonitorType returns monitor type.
@@ -195,7 +197,7 @@ type MonitorExternalHTTP struct {
 
 	Method                          string  `json:"method,omitempty"`
 	URL                             string  `json:"url,omitempty"`
-	MaxCheckAttempts                float64 `json:"maxCheckAttempts,omitempty"`
+	MaxCheckAttempts                uint64  `json:"maxCheckAttempts,omitempty"`
 	Service                         string  `json:"service,omitempty"`
 	ResponseTimeCritical            float64 `json:"responseTimeCritical,omitempty"`
 	ResponseTimeWarning             float64 `json:"responseTimeWarning,omitempty"`

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -101,6 +101,9 @@ func TestFindMonitors(t *testing.T) {
 		if m.URL != "https://www.example.com/" {
 			t.Error("request sends json including url but: ", m)
 		}
+		if m.MaxCheckAttempts != 3 {
+			t.Error("request sends json including maxCheckAttempts but: ", m)
+		}
 		if m.ResponseTimeCritical != 5000 {
 			t.Error("request sends json including responseTimeCritical but: ", m)
 		}
@@ -194,6 +197,7 @@ const monitorsjson = `
       "operator": ">",
       "warning": 20000.0,
       "critical": 400000.0,
+      "maxCheckAttempts": 3,
       "scopes": [
         "Hatena-Blog"
       ],
@@ -211,6 +215,7 @@ const monitorsjson = `
       "operator": ">",
       "warning": 50.0,
       "critical": 100.0,
+      "maxCheckAttempts": 5,
       "notificationInterval": 60
     },
     {
@@ -221,7 +226,8 @@ const monitorsjson = `
       "url": "https://example.com",
       "service": "Hatena-Blog",
       "headers": [{"name":"Cache-Control", "value":"no-cache"}],
-      "requestBody": "Request Body"
+      "requestBody": "Request Body",
+      "maxCheckAttempts": 7
     },
     {
       "id"  : "2cSZzK3XfmE",
@@ -258,6 +264,7 @@ var wantMonitors = []Monitor{
 		Warning:              20000.000000,
 		Critical:             400000.000000,
 		Duration:             3,
+		MaxCheckAttempts:     3,
 		Scopes: []string{
 			"Hatena-Blog",
 		},
@@ -277,6 +284,7 @@ var wantMonitors = []Monitor{
 		Warning:              50.000000,
 		Critical:             100.000000,
 		Duration:             1,
+		MaxCheckAttempts:     5,
 	},
 	&MonitorExternalHTTP{
 		ID:                              "2cSZzK3XfmD",
@@ -286,7 +294,7 @@ var wantMonitors = []Monitor{
 		NotificationInterval:            0,
 		Method:                          "POST",
 		URL:                             "https://example.com",
-		MaxCheckAttempts:                0.000000,
+		MaxCheckAttempts:                7,
 		Service:                         "Hatena-Blog",
 		ResponseTimeCritical:            0.000000,
 		ResponseTimeWarning:             0.000000,


### PR DESCRIPTION
This pull request add support for maxCheckAttempts configuration for host metric and service metric monitors.
For reference: [API document](https://mackerel.io/api-docs/entry/monitors) ([ja](https://mackerel.io/ja/api-docs/entry/monitors)).