### PR TITLE
Expose http.Client to make the library work on GAE

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -24,6 +24,7 @@ type Client struct {
 	Verbose           bool
 	UserAgent         string
 	AdditionalHeaders http.Header
+	HTTPClient        *http.Client
 }
 
 func init() {
@@ -33,7 +34,7 @@ func init() {
 // NewClient returns new mackerel.Client
 func NewClient(apikey string) *Client {
 	u, _ := url.Parse(defaultBaseURL)
-	return &Client{u, apikey, false, defaultUserAgent, http.Header{}}
+	return &Client{u, apikey, false, defaultUserAgent, http.Header{}, &http.Client{}}
 }
 
 // NewClientWithOptions returns new mackerel.Client
@@ -42,7 +43,7 @@ func NewClientWithOptions(apikey string, rawurl string, verbose bool) (*Client, 
 	if err != nil {
 		return nil, err
 	}
-	return &Client{u, apikey, verbose, defaultUserAgent, http.Header{}}, nil
+	return &Client{u, apikey, verbose, defaultUserAgent, http.Header{}, &http.Client{}}, nil
 }
 
 func (c *Client) urlFor(path string) *url.URL {
@@ -78,7 +79,7 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 		}
 	}
 
-	client := &http.Client{} // same as http.DefaultClient
+	client := c.HTTPClient
 	client.Timeout = apiRequestTimeout
 	resp, err = client.Do(req)
 	if err != nil {


### PR DESCRIPTION
On Google App Engine Go Standard Environment, we have to use `urlfetch` instead of `net/http`.

`urlfetch.Client(ctx)` returns a `net/http.Client` instance that can issue HTTP(S) request on GAE environment, and we should pass it to mackerel-client-go.

See also: https://cloud.google.com/appengine/docs/standard/go/issue-requests

(Yes, I understand that any changes should be with tests, but I have no good idea...)