### PR TITLE
Support empty threshold for monitors

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -141,12 +141,12 @@ type MonitorHostMetric struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Metric           string  `json:"metric,omitempty"`
-	Operator         string  `json:"operator,omitempty"`
-	Warning          float64 `json:"warning"`
-	Critical         float64 `json:"critical"`
-	Duration         uint64  `json:"duration,omitempty"`
-	MaxCheckAttempts uint64  `json:"maxCheckAttempts,omitempty"`
+	Metric           string   `json:"metric,omitempty"`
+	Operator         string   `json:"operator,omitempty"`
+	Warning          *float64 `json:"warning"`
+	Critical         *float64 `json:"critical"`
+	Duration         uint64   `json:"duration,omitempty"`
+	MaxCheckAttempts uint64   `json:"maxCheckAttempts,omitempty"`
 
 	Scopes        []string `json:"scopes,omitempty"`
 	ExcludeScopes []string `json:"excludeScopes,omitempty"`
@@ -170,13 +170,13 @@ type MonitorServiceMetric struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Service          string  `json:"service,omitempty"`
-	Metric           string  `json:"metric,omitempty"`
-	Operator         string  `json:"operator,omitempty"`
-	Warning          float64 `json:"warning"`
-	Critical         float64 `json:"critical"`
-	Duration         uint64  `json:"duration,omitempty"`
-	MaxCheckAttempts uint64  `json:"maxCheckAttempts,omitempty"`
+	Service          string   `json:"service,omitempty"`
+	Metric           string   `json:"metric,omitempty"`
+	Operator         string   `json:"operator,omitempty"`
+	Warning          *float64 `json:"warning"`
+	Critical         *float64 `json:"critical"`
+	Duration         uint64   `json:"duration,omitempty"`
+	MaxCheckAttempts uint64   `json:"maxCheckAttempts,omitempty"`
 }
 
 // MonitorType returns monitor type.
@@ -197,18 +197,18 @@ type MonitorExternalHTTP struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Method                          string  `json:"method,omitempty"`
-	URL                             string  `json:"url,omitempty"`
-	MaxCheckAttempts                uint64  `json:"maxCheckAttempts,omitempty"`
-	Service                         string  `json:"service,omitempty"`
-	ResponseTimeCritical            float64 `json:"responseTimeCritical,omitempty"`
-	ResponseTimeWarning             float64 `json:"responseTimeWarning,omitempty"`
-	ResponseTimeDuration            float64 `json:"responseTimeDuration,omitempty"`
-	RequestBody                     string  `json:"requestBody,omitempty"`
-	ContainsString                  string  `json:"containsString,omitempty"`
-	CertificationExpirationCritical uint64  `json:"certificationExpirationCritical,omitempty"`
-	CertificationExpirationWarning  uint64  `json:"certificationExpirationWarning,omitempty"`
-	SkipCertificateVerification     bool    `json:"skipCertificateVerification,omitempty"`
+	Method                          string   `json:"method,omitempty"`
+	URL                             string   `json:"url,omitempty"`
+	MaxCheckAttempts                uint64   `json:"maxCheckAttempts,omitempty"`
+	Service                         string   `json:"service,omitempty"`
+	ResponseTimeCritical            *float64 `json:"responseTimeCritical,omitempty"`
+	ResponseTimeWarning             *float64 `json:"responseTimeWarning,omitempty"`
+	ResponseTimeDuration            *uint64  `json:"responseTimeDuration,omitempty"`
+	RequestBody                     string   `json:"requestBody,omitempty"`
+	ContainsString                  string   `json:"containsString,omitempty"`
+	CertificationExpirationCritical *uint64  `json:"certificationExpirationCritical,omitempty"`
+	CertificationExpirationWarning  *uint64  `json:"certificationExpirationWarning,omitempty"`
+	SkipCertificateVerification     bool     `json:"skipCertificateVerification,omitempty"`
 	// Empty list of headers and nil are different. You have to specify empty
 	// list as headers explicitly if you want to remove all headers instead of
 	// using nil.
@@ -240,10 +240,10 @@ type MonitorExpression struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Expression string  `json:"expression,omitempty"`
-	Operator   string  `json:"operator,omitempty"`
-	Warning    float64 `json:"warning"`
-	Critical   float64 `json:"critical"`
+	Expression string   `json:"expression,omitempty"`
+	Operator   string   `json:"operator,omitempty"`
+	Warning    *float64 `json:"warning"`
+	Critical   *float64 `json:"critical"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -187,372 +187,367 @@ func TestMonitorExternalHTTP_headers(t *testing.T) {
 	}
 }
 
-const monitorsjson = `
-{
-  "monitors": [
-    {
-      "id": "2cSZzK3XfmA",
-      "type": "connectivity",
-      "scopes": [],
-      "excludeScopes": []
-    },
-    {
-      "id"  : "2cSZzK3XfmB",
-      "type": "host",
-      "name": "disk.aa-00.writes.delta",
-      "duration": 3,
-      "metric": "disk.aa-00.writes.delta",
-      "operator": ">",
-      "warning": 20000.0,
-      "critical": 400000.0,
-      "maxCheckAttempts": 3,
-      "scopes": [
-        "Hatena-Blog"
-      ],
-      "excludeScopes": [
-        "Hatena-Bookmark: db-master"
-      ]
-    },
-    {
-      "id"  : "2cSZzK3XfmF",
-      "type": "host",
-      "name": "Foo Bar",
-      "duration": 3,
-      "metric": "custom.foo.bar",
-      "operator": ">",
-      "warning": 200.0,
-      "maxCheckAttempts": 5
-    },
-    {
-      "id"  : "2cSZzK3XfmC",
-      "type": "service",
-      "name": "Hatena-Blog - access_num.4xx_count",
-      "service": "Hatena-Blog",
-      "duration": 1,
-      "metric": "access_num.4xx_count",
-      "operator": ">",
-      "warning": 50.0,
-      "critical": 100.0,
-      "maxCheckAttempts": 5,
-      "notificationInterval": 60
-    },
-    {
-      "id"  : "2cSZzK3XfmG",
-      "type": "service",
-      "name": "Hatena-Blog - access_num.5xx_count",
-      "service": "Hatena-Blog",
-      "duration": 3,
-      "metric": "access_num.5xx_count",
-      "operator": ">",
-      "critical": 100.0,
-      "maxCheckAttempts": 3,
-      "notificationInterval": 60
-    },
-    {
-      "id"  : "2cSZzK3XfmD",
-      "type": "external",
-      "name": "example.com",
-      "method": "POST",
-      "url": "https://example.com",
-      "service": "Hatena-Blog",
-      "headers": [{"name":"Cache-Control", "value":"no-cache"}],
-      "requestBody": "Request Body",
-      "maxCheckAttempts": 7,
-      "responseTimeCritical": 3000,
-      "responseTimeWarning": 2000,
-      "responseTimeDuration": 7,
-      "certificationExpirationCritical": 60,
-      "certificationExpirationWarning": 90
-    },
-    {
-      "id"  : "2cSZzK3XfmH",
-      "type": "external",
-      "name": "example.com",
-      "method": "GET",
-      "url": "https://example.com",
-      "service": "Hatena-Blog",
-      "headers": [{"name":"Cache-Control", "value":"no-cache"}],
-      "requestBody": "Request Body",
-      "maxCheckAttempts": 5,
-      "responseTimeWarning": 3000,
-      "responseTimeDuration": 7,
-      "certificationExpirationCritical": 30
-    },
-    {
-      "id"  : "2cSZzK3XfmE",
-      "type": "expression",
-      "name": "role average",
-      "expression": "avg(roleSlots(\"server:role\",\"loadavg5\"))",
-      "operator": ">",
-      "warning": 5.0,
-      "critical": 10.0,
-      "notificationInterval": 60
-    }
-  ]
-}
-`
-
-var wantMonitors = []Monitor{
-	&MonitorConnectivity{
-		ID:                   "2cSZzK3XfmA",
-		Name:                 "",
-		Type:                 "connectivity",
-		IsMute:               false,
-		NotificationInterval: 0,
-		Scopes:               []string{},
-		ExcludeScopes:        []string{},
-	},
-	&MonitorHostMetric{
-		ID:                   "2cSZzK3XfmB",
-		Name:                 "disk.aa-00.writes.delta",
-		Type:                 "host",
-		IsMute:               false,
-		NotificationInterval: 0,
-		Metric:               "disk.aa-00.writes.delta",
-		Operator:             ">",
-		Warning:              pfloat64(20000.000000),
-		Critical:             pfloat64(400000.000000),
-		Duration:             3,
-		MaxCheckAttempts:     3,
-		Scopes: []string{
-			"Hatena-Blog",
+var testCases = []struct {
+	title   string
+	monitor Monitor
+	json    string
+}{
+	{
+		"connectivity",
+		&MonitorConnectivity{
+			ID:                   "2cSZzK3XfmA",
+			Name:                 "",
+			Type:                 "connectivity",
+			IsMute:               false,
+			NotificationInterval: 0,
+			Scopes:               nil,
+			ExcludeScopes:        nil,
 		},
-		ExcludeScopes: []string{
-			"Hatena-Bookmark: db-master",
-		},
+		`{
+			"id": "2cSZzK3XfmA",
+			"type": "connectivity"
+		}`,
 	},
-	&MonitorHostMetric{
-		ID:                   "2cSZzK3XfmF",
-		Name:                 "Foo Bar",
-		Type:                 "host",
-		IsMute:               false,
-		NotificationInterval: 0,
-		Metric:               "custom.foo.bar",
-		Operator:             ">",
-		Warning:              pfloat64(200.0),
-		Critical:             nil,
-		Duration:             3,
-		MaxCheckAttempts:     5,
-		Scopes:               nil,
-		ExcludeScopes:        nil,
-	},
-	&MonitorServiceMetric{
-		ID:                   "2cSZzK3XfmC",
-		Name:                 "Hatena-Blog - access_num.4xx_count",
-		Type:                 "service",
-		IsMute:               false,
-		NotificationInterval: 60,
-		Service:              "Hatena-Blog",
-		Metric:               "access_num.4xx_count",
-		Operator:             ">",
-		Warning:              pfloat64(50.000000),
-		Critical:             pfloat64(100.000000),
-		Duration:             1,
-		MaxCheckAttempts:     5,
-	},
-	&MonitorServiceMetric{
-		ID:                   "2cSZzK3XfmG",
-		Name:                 "Hatena-Blog - access_num.5xx_count",
-		Type:                 "service",
-		IsMute:               false,
-		NotificationInterval: 60,
-		Service:              "Hatena-Blog",
-		Metric:               "access_num.5xx_count",
-		Operator:             ">",
-		Warning:              nil,
-		Critical:             pfloat64(100.000000),
-		Duration:             3,
-		MaxCheckAttempts:     3,
-	},
-	&MonitorExternalHTTP{
-		ID:                              "2cSZzK3XfmD",
-		Name:                            "example.com",
-		Type:                            "external",
-		IsMute:                          false,
-		NotificationInterval:            0,
-		Method:                          "POST",
-		URL:                             "https://example.com",
-		MaxCheckAttempts:                7,
-		Service:                         "Hatena-Blog",
-		ResponseTimeCritical:            pfloat64(3000.0),
-		ResponseTimeWarning:             pfloat64(2000.0),
-		ResponseTimeDuration:            puint64(7),
-		RequestBody:                     "Request Body",
-		ContainsString:                  "",
-		CertificationExpirationCritical: puint64(60),
-		CertificationExpirationWarning:  puint64(90),
-		SkipCertificateVerification:     false,
-		Headers: []HeaderField{
-			{
-				Name:  "Cache-Control",
-				Value: "no-cache",
+	{
+		"host metric monitor",
+		&MonitorHostMetric{
+			ID:                   "2cSZzK3XfmB",
+			Name:                 "disk.aa-00.writes.delta",
+			Type:                 "host",
+			IsMute:               false,
+			NotificationInterval: 0,
+			Metric:               "disk.aa-00.writes.delta",
+			Operator:             ">",
+			Warning:              pfloat64(20000.000000),
+			Critical:             pfloat64(400000.000000),
+			Duration:             3,
+			MaxCheckAttempts:     3,
+			Scopes: []string{
+				"Hatena-Blog",
+			},
+			ExcludeScopes: []string{
+				"Hatena-Bookmark: db-master",
 			},
 		},
+		`{
+			"id": "2cSZzK3XfmB",
+			"type": "host",
+			"name": "disk.aa-00.writes.delta",
+			"duration": 3,
+			"metric": "disk.aa-00.writes.delta",
+			"operator": ">",
+			"warning": 20000,
+			"critical": 400000,
+			"maxCheckAttempts": 3,
+			"scopes": [
+			"Hatena-Blog"
+			],
+			"excludeScopes": [
+			"Hatena-Bookmark: db-master"
+			]
+		}`,
 	},
-	&MonitorExternalHTTP{
-		ID:                              "2cSZzK3XfmH",
-		Name:                            "example.com",
-		Type:                            "external",
-		IsMute:                          false,
-		NotificationInterval:            0,
-		Method:                          "GET",
-		URL:                             "https://example.com",
-		MaxCheckAttempts:                5,
-		Service:                         "Hatena-Blog",
-		ResponseTimeCritical:            nil,
-		ResponseTimeWarning:             pfloat64(3000.0),
-		ResponseTimeDuration:            puint64(7),
-		RequestBody:                     "Request Body",
-		ContainsString:                  "",
-		CertificationExpirationCritical: puint64(30),
-		CertificationExpirationWarning:  nil,
-		SkipCertificateVerification:     false,
-		Headers: []HeaderField{
-			{
-				Name:  "Cache-Control",
-				Value: "no-cache",
+	{
+		"host metric monitor without critical threshold",
+		&MonitorHostMetric{
+			ID:                   "2cSZzK3XfmF",
+			Name:                 "Foo Bar",
+			Type:                 "host",
+			IsMute:               false,
+			NotificationInterval: 0,
+			Metric:               "custom.foo.bar",
+			Operator:             ">",
+			Warning:              pfloat64(200.0),
+			Critical:             nil,
+			Duration:             3,
+			MaxCheckAttempts:     5,
+			Scopes:               nil,
+			ExcludeScopes:        nil,
+		},
+		`{
+			"id": "2cSZzK3XfmF",
+			"type": "host",
+			"name": "Foo Bar",
+			"duration": 3,
+			"metric": "custom.foo.bar",
+			"operator": ">",
+			"warning": 200.0,
+			"critical": null,
+			"maxCheckAttempts": 5
+		}`,
+	},
+	{
+		"host metric monitor without warning threshold",
+		&MonitorHostMetric{
+			ID:                   "2cSZzK3XfmX",
+			Name:                 "Foo Baz",
+			Type:                 "host",
+			IsMute:               false,
+			NotificationInterval: 0,
+			Metric:               "custom.foo.baz",
+			Operator:             "<",
+			Warning:              nil,
+			Critical:             pfloat64(300),
+			Duration:             7,
+			MaxCheckAttempts:     2,
+			Scopes:               nil,
+			ExcludeScopes:        nil,
+		},
+		`{
+			"id": "2cSZzK3XfmX",
+			"type": "host",
+			"name": "Foo Baz",
+			"duration": 7,
+			"metric": "custom.foo.baz",
+			"operator": "<",
+			"warning": null,
+			"critical": 300.0,
+			"maxCheckAttempts": 2
+		}`,
+	},
+	{
+		"service metric monitor",
+		&MonitorServiceMetric{
+			ID:                   "2cSZzK3XfmC",
+			Name:                 "Hatena-Blog - access_num.4xx_count",
+			Type:                 "service",
+			IsMute:               false,
+			NotificationInterval: 60,
+			Service:              "Hatena-Blog",
+			Metric:               "access_num.4xx_count",
+			Operator:             ">",
+			Warning:              pfloat64(50.000000),
+			Critical:             pfloat64(100.000000),
+			Duration:             1,
+			MaxCheckAttempts:     5,
+		},
+		`{
+			"id"  : "2cSZzK3XfmC",
+			"type": "service",
+			"name": "Hatena-Blog - access_num.4xx_count",
+			"service": "Hatena-Blog",
+			"duration": 1,
+			"metric": "access_num.4xx_count",
+			"operator": ">",
+			"warning": 50.0,
+			"critical": 100.0,
+			"maxCheckAttempts": 5,
+			"notificationInterval": 60
+		}`,
+	},
+	{
+		"service metric monitor without warning threshold",
+		&MonitorServiceMetric{
+			ID:                   "2cSZzK3XfmG",
+			Name:                 "Hatena-Blog - access_num.5xx_count",
+			Type:                 "service",
+			IsMute:               false,
+			NotificationInterval: 60,
+			Service:              "Hatena-Blog",
+			Metric:               "access_num.5xx_count",
+			Operator:             ">",
+			Warning:              nil,
+			Critical:             pfloat64(0.0),
+			Duration:             3,
+			MaxCheckAttempts:     3,
+		},
+		`{
+			"id"  : "2cSZzK3XfmG",
+			"type": "service",
+			"name": "Hatena-Blog - access_num.5xx_count",
+			"service": "Hatena-Blog",
+			"duration": 3,
+			"metric": "access_num.5xx_count",
+			"operator": ">",
+			"critical": 0.0,
+			"warning": null,
+			"maxCheckAttempts": 3,
+			"notificationInterval": 60
+		}`,
+	},
+	{
+		"external monitor",
+		&MonitorExternalHTTP{
+			ID:                              "2cSZzK3XfmD",
+			Name:                            "example.com",
+			Type:                            "external",
+			IsMute:                          false,
+			NotificationInterval:            0,
+			Method:                          "POST",
+			URL:                             "https://example.com",
+			MaxCheckAttempts:                7,
+			Service:                         "Hatena-Blog",
+			ResponseTimeCritical:            pfloat64(3000.0),
+			ResponseTimeWarning:             pfloat64(2000.0),
+			ResponseTimeDuration:            puint64(7),
+			RequestBody:                     "Request Body",
+			ContainsString:                  "",
+			CertificationExpirationCritical: puint64(60),
+			CertificationExpirationWarning:  puint64(90),
+			SkipCertificateVerification:     false,
+			Headers: []HeaderField{
+				{
+					Name:  "Cache-Control",
+					Value: "no-cache",
+				},
 			},
 		},
+		`{
+			"id"  : "2cSZzK3XfmD",
+			"type": "external",
+			"name": "example.com",
+			"method": "POST",
+			"url": "https://example.com",
+			"service": "Hatena-Blog",
+			"headers": [{"name":"Cache-Control", "value":"no-cache"}],
+			"requestBody": "Request Body",
+			"maxCheckAttempts": 7,
+			"responseTimeCritical": 3000,
+			"responseTimeWarning": 2000,
+			"responseTimeDuration": 7,
+			"certificationExpirationCritical": 60,
+			"certificationExpirationWarning": 90
+		}`,
 	},
-	&MonitorExpression{
-		ID:                   "2cSZzK3XfmE",
-		Name:                 "role average",
-		Type:                 "expression",
-		IsMute:               false,
-		NotificationInterval: 60,
-		Expression:           "avg(roleSlots(\"server:role\",\"loadavg5\"))",
-		Operator:             ">",
-		Warning:              pfloat64(5.000000),
-		Critical:             pfloat64(10.000000),
+	{
+		"external monitor without service",
+		&MonitorExternalHTTP{
+			ID:               "2cSZzK3XfmY",
+			Name:             "POST example.com",
+			Type:             "external",
+			Method:           "POST",
+			URL:              "https://example.com",
+			MaxCheckAttempts: 5,
+			RequestBody:      "Request Body",
+			ContainsString:   "",
+			Headers:          []HeaderField{},
+		},
+		`{
+			"id"  : "2cSZzK3XfmY",
+			"type": "external",
+			"name": "POST example.com",
+			"method": "POST",
+			"url": "https://example.com",
+			"headers": [],
+			"requestBody": "Request Body",
+			"maxCheckAttempts": 5
+		}`,
+	},
+	{
+		"external monitor with empty threshold",
+		&MonitorExternalHTTP{
+			ID:                              "2cSZzK3XfmH",
+			Name:                            "example.com",
+			Type:                            "external",
+			IsMute:                          false,
+			NotificationInterval:            0,
+			Method:                          "GET",
+			URL:                             "https://example.com",
+			MaxCheckAttempts:                5,
+			Service:                         "Hatena-Blog",
+			ResponseTimeCritical:            nil,
+			ResponseTimeWarning:             pfloat64(3000.0),
+			ResponseTimeDuration:            puint64(7),
+			RequestBody:                     "Request Body",
+			ContainsString:                  "",
+			CertificationExpirationCritical: puint64(30),
+			CertificationExpirationWarning:  nil,
+			SkipCertificateVerification:     false,
+			Headers: []HeaderField{
+				{
+					Name:  "Cache-Control",
+					Value: "no-cache",
+				},
+			},
+		},
+		`{
+			"id"  : "2cSZzK3XfmH",
+			"type": "external",
+			"name": "example.com",
+			"method": "GET",
+			"url": "https://example.com",
+			"service": "Hatena-Blog",
+			"headers": [{"name":"Cache-Control", "value":"no-cache"}],
+			"requestBody": "Request Body",
+			"maxCheckAttempts": 5,
+			"responseTimeWarning": 3000,
+			"responseTimeDuration": 7,
+			"certificationExpirationCritical": 30
+		}`,
+	},
+	{
+		"expression monitor",
+		&MonitorExpression{
+			ID:                   "2cSZzK3XfmE",
+			Name:                 "role average",
+			Type:                 "expression",
+			IsMute:               false,
+			NotificationInterval: 60,
+			Expression:           "avg(roleSlots(\"server:role\",\"loadavg5\"))",
+			Operator:             ">",
+			Warning:              pfloat64(5.000000),
+			Critical:             pfloat64(10.000000),
+		},
+		`{
+			"id"  : "2cSZzK3XfmE",
+			"type": "expression",
+			"name": "role average",
+			"expression": "avg(roleSlots(\"server:role\",\"loadavg5\"))",
+			"operator": ">",
+			"warning": 5.0,
+			"critical": 10.0,
+			"notificationInterval": 60
+		}`,
+	},
+	{
+		"expression monitor without thresholds",
+		&MonitorExpression{
+			ID:                   "2cSZzK3XfmE",
+			Name:                 "role average",
+			Type:                 "expression",
+			IsMute:               false,
+			NotificationInterval: 60,
+			Expression:           "avg(roleSlots(\"server:role\",\"loadavg5\"))",
+			Operator:             ">",
+			Warning:              nil,
+			Critical:             nil,
+		},
+		`{
+			"id"  : "2cSZzK3XfmE",
+			"type": "expression",
+			"name": "role average",
+			"expression": "avg(roleSlots(\"server:role\",\"loadavg5\"))",
+			"operator": ">",
+			"warning": null,
+			"critical": null,
+			"notificationInterval": 60
+		}`,
 	},
 }
 
-func TestDecodeMonitor(t *testing.T) {
-	if got := decodeMonitorsJSON(t); !reflect.DeepEqual(got, wantMonitors) {
-		t.Errorf("fail to get correct data: diff: (-got +want)\n%v", pretty.Compare(got, wantMonitors))
-	}
-}
-
-func BenchmarkDecodeMonitor(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		decodeMonitorsJSON(b)
-	}
-}
-
-func decodeMonitorsJSON(t testing.TB) []Monitor {
-	var data struct {
-		Monitors []json.RawMessage `json:"monitors"`
-	}
-	if err := json.NewDecoder(strings.NewReader(monitorsjson)).Decode(&data); err != nil {
-		t.Error(err)
-	}
-	ms := make([]Monitor, 0, len(data.Monitors))
-	for _, rawmes := range data.Monitors {
-		m, err := decodeMonitor(rawmes)
+func TestDecodeEncodeMonitor(t *testing.T) {
+	for _, testCase := range testCases {
+		gotMonitor, err := decodeMonitorReader(strings.NewReader(testCase.json))
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%s: err shoud be nil but: %v", testCase.title, err)
 		}
-		ms = append(ms, m)
+		if !reflect.DeepEqual(gotMonitor, testCase.monitor) {
+			t.Errorf("%s: fail to get correct data: diff: (-got +want)\n%v", testCase.title, pretty.Compare(gotMonitor, testCase.monitor))
+		}
+
+		b, err := json.MarshalIndent(testCase.monitor, "", "    ")
+		if err != nil {
+			t.Errorf("%s: err shoud be nil but: %v", testCase.title, err)
+		}
+		if gotJson := string(b); !equalJSON(gotJson, testCase.json) {
+			t.Errorf("%s: got %v, want %v", testCase.title, gotJson, testCase.json)
+		}
 	}
-	return ms
 }
 
-var monitorsToBeEncoded = []Monitor{
-	&MonitorHostMetric{
-		ID:       "2cSZzK3XfmA",
-		Warning:  pfloat64(0.000000),
-		Critical: pfloat64(400000.000000),
-	},
-	&MonitorHostMetric{
-		ID:      "2cSZzK3XfmB",
-		Warning: pfloat64(600000.000000),
-	},
-	&MonitorHostMetric{
-		ID:       "2cSZzK3XfmB",
-		Critical: pfloat64(500000.000000),
-	},
-	&MonitorServiceMetric{
-		ID:       "2cSZzK3XfmC",
-		Warning:  pfloat64(50.000000),
-		Critical: pfloat64(0.000000),
-	},
-	&MonitorServiceMetric{
-		ID:      "2cSZzK3XfmC",
-		Warning: pfloat64(50.000000),
-	},
-	&MonitorServiceMetric{
-		ID:       "2cSZzK3XfmC",
-		Critical: pfloat64(0.000000),
-	},
-	&MonitorExpression{
-		ID:       "2cSZzK3XfmE",
-		Warning:  pfloat64(0.000000),
-		Critical: pfloat64(0.000000),
-	},
-	&MonitorExpression{
-		ID:      "2cSZzK3XfmE",
-		Warning: pfloat64(0.000000),
-	},
-	&MonitorExpression{
-		ID:       "2cSZzK3XfmE",
-		Critical: pfloat64(0.000000),
-	},
-}
-
-func TestEncodeMonitor(t *testing.T) {
-	b, err := json.MarshalIndent(monitorsToBeEncoded, "", "    ")
-	if err != nil {
-		t.Error("err shoud be nil but: ", err)
-	}
-
-	want := `[
-    {
-        "id": "2cSZzK3XfmA",
-        "warning": 0,
-        "critical": 400000
-    },
-    {
-        "id": "2cSZzK3XfmB",
-        "warning": 600000,
-        "critical": null
-    },
-    {
-        "id": "2cSZzK3XfmB",
-        "warning": null,
-        "critical": 500000
-    },
-    {
-        "id": "2cSZzK3XfmC",
-        "warning": 50,
-        "critical": 0
-    },
-    {
-        "id": "2cSZzK3XfmC",
-        "warning": 50,
-        "critical": null
-    },
-    {
-        "id": "2cSZzK3XfmC",
-        "warning": null,
-        "critical": 0
-    },
-    {
-        "id": "2cSZzK3XfmE",
-        "warning": 0,
-        "critical": 0
-    },
-    {
-        "id": "2cSZzK3XfmE",
-        "warning": 0,
-        "critical": null
-    },
-    {
-        "id": "2cSZzK3XfmE",
-        "warning": null,
-        "critical": 0
-    }
-]`
-	if got := string(b); got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
+func equalJSON(x, y string) bool {
+	var xval, yval interface{}
+	json.Unmarshal([]byte(x), &xval)
+	json.Unmarshal([]byte(y), &yval)
+	return reflect.DeepEqual(xval, yval)
 }

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -539,8 +539,8 @@ func TestDecodeEncodeMonitor(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: err shoud be nil but: %v", testCase.title, err)
 		}
-		if gotJson := string(b); !equalJSON(gotJson, testCase.json) {
-			t.Errorf("%s: got %v, want %v", testCase.title, gotJson, testCase.json)
+		if gotJSON := string(b); !equalJSON(gotJSON, testCase.json) {
+			t.Errorf("%s: got %v, want %v", testCase.title, gotJSON, testCase.json)
 		}
 	}
 }


### PR DESCRIPTION
We recently support configuring monitors with empty warning/critical threshold (skipping the monitoring), which allows users to create a monitor which emits only warning (or critical) alerts. Thresholds are numbers and we have to distinguish 0 with empty threshold so I changed them to pointers of number.