### PR TITLE
remove log.SetFlags

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -27,10 +27,6 @@ type Client struct {
 	HTTPClient        *http.Client
 }
 
-func init() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-}
-
 // NewClient returns new mackerel.Client
 func NewClient(apikey string) *Client {
 	u, _ := url.Parse(defaultBaseURL)


### PR DESCRIPTION
ref #57 

It is not a good practice calling `log.SetFlags` at the library level, so remove them.