### PR TITLE
change Cloud of HostMeta to pointer

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -39,7 +39,7 @@ type HostMeta struct {
 	Filesystem    FileSystem  `json:"filesystem,omitempty"`
 	Kernel        Kernel      `json:"kernel,omitempty"`
 	Memory        Memory      `json:"memory,omitempty"`
-	Cloud         Cloud       `json:"cloud,omitempty"`
+	Cloud         *Cloud      `json:"cloud,omitempty"`
 }
 
 // BlockDevice blockdevice


### PR DESCRIPTION
Empty `Cloud{}` is not be omitted by `omitempty` JSON tag. This results into the unwanted `"cloud": {}` in the meta data. This is a breaking change but detectable by compile error.