### PR TITLE
Adjust json tag

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -11,19 +11,19 @@ import (
 
 // Host host information
 type Host struct {
-	ID               string      `json:"id,omitempty"`
-	Name             string      `json:"name,omitempty"`
+	ID               string      `json:"id"`
+	Name             string      `json:"name"`
 	DisplayName      string      `json:"displayName,omitempty"`
 	CustomIdentifier string      `json:"customIdentifier,omitempty"`
-	Type             string      `json:"type,omitempty"`
-	Status           string      `json:"status,omitempty"`
-	Memo             string      `json:"memo,omitempty"`
-	Roles            Roles       `json:"roles,omitempty"`
+	Type             string      `json:"type"`
+	Status           string      `json:"status"`
+	Memo             string      `json:"memo"`
+	Roles            Roles       `json:"roles"`
 	RoleFullnames    []string    `json:"roleFullnames,omitempty"`
-	IsRetired        bool        `json:"isRetired,omitempty"`
-	CreatedAt        int32       `json:"createdAt,omitempty"`
-	Meta             HostMeta    `json:"meta,omitempty"`
-	Interfaces       []Interface `json:"interfaces,omitempty"`
+	IsRetired        bool        `json:"isRetired"`
+	CreatedAt        int32       `json:"createdAt"`
+	Meta             HostMeta    `json:"meta"`
+	Interfaces       []Interface `json:"interfaces"`
 }
 
 // Roles host role maps
@@ -83,9 +83,9 @@ type FindHostsParam struct {
 
 // CreateHostParam parameters for CreateHost
 type CreateHostParam struct {
-	Name             string        `json:"name,omitempty"`
+	Name             string        `json:"name"`
 	DisplayName      string        `json:"displayName,omitempty"`
-	Meta             HostMeta      `json:"meta,omitempty"`
+	Meta             HostMeta      `json:"meta"`
 	Interfaces       []Interface   `json:"interfaces,omitempty"`
 	RoleFullnames    []string      `json:"roleFullnames,omitempty"`
 	Checks           []CheckConfig `json:"checks,omitempty"`

--- a/roles.go
+++ b/roles.go
@@ -8,15 +8,12 @@ import (
 
 // Role represents Mackerel "role".
 type Role struct {
-	Name string
-	Memo string
-}
-
-// CreateRoleParam parameters for CreateRole
-type CreateRoleParam struct {
 	Name string `json:"name"`
 	Memo string `json:"memo"`
 }
+
+// CreateRoleParam parameters for CreateRole
+type CreateRoleParam Role
 
 // CreateRole creates role.
 func (c *Client) CreateRole(serviceName string, param *CreateRoleParam) (*Role, error) {

--- a/services.go
+++ b/services.go
@@ -8,9 +8,9 @@ import (
 
 // Service represents Mackerel "service".
 type Service struct {
-	Name  string   `json:"name,omitempty"`
-	Memo  string   `json:"memo,omitempty"`
-	Roles []string `json:"roles,omitempty"`
+	Name  string   `json:"name"`
+	Memo  string   `json:"memo"`
+	Roles []string `json:"roles"`
 }
 
 // CreateServiceParam parameters for CreateService


### PR DESCRIPTION
## Add missing JSON tags for `Role` struct

Fields of `Role` didn't have json tag, so I added them.
Though decoding JSON response from Roles API works without those tags, imo it's better to declare explicitly.

## Remove excess `omitempty` from some fields.

Some fields have excess `omietmpty` option in JSON tag.

I removed `omitempty` from:
- Some keys in `Services` and `Hosts`, which always exists in API response
- Mandatory Key in  `CreateHostParam`