### PR TITLE
[Breaking change] Remove `RoleFullnames` field from `Host`

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -19,7 +19,6 @@ type Host struct {
 	Status           string      `json:"status"`
 	Memo             string      `json:"memo"`
 	Roles            Roles       `json:"roles"`
-	RoleFullnames    []string    `json:"roleFullnames,omitempty"`
 	IsRetired        bool        `json:"isRetired"`
 	CreatedAt        int32       `json:"createdAt"`
 	Meta             HostMeta    `json:"meta"`


### PR DESCRIPTION
Historically `Host`, used as response of Hosts API, has `RoleFullnames` field, but this field is never filled.  Therefore I'd like to remove it. 
(ref: api-doc https://mackerel.io/ja/api-docs/entry/hosts )
