### PR TITLE
set http request timeout in constructor

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -28,8 +28,8 @@ type Client struct {
 
 // NewClient returns new mackerel.Client
 func NewClient(apikey string) *Client {
-	u, _ := url.Parse(defaultBaseURL)
-	return &Client{u, apikey, false, defaultUserAgent, http.Header{}, &http.Client{}}
+	c, _ := NewClientWithOptions(apikey, defaultBaseURL, false)
+	return c
 }
 
 // NewClientWithOptions returns new mackerel.Client
@@ -38,7 +38,9 @@ func NewClientWithOptions(apikey string, rawurl string, verbose bool) (*Client, 
 	if err != nil {
 		return nil, err
 	}
-	return &Client{u, apikey, verbose, defaultUserAgent, http.Header{}, &http.Client{}}, nil
+	client := &http.Client{}
+	client.Timeout = apiRequestTimeout
+	return &Client{u, apikey, verbose, defaultUserAgent, http.Header{}, client}, nil
 }
 
 func (c *Client) urlFor(path string) *url.URL {
@@ -74,9 +76,7 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 		}
 	}
 
-	client := c.HTTPClient
-	client.Timeout = apiRequestTimeout
-	resp, err = client.Do(req)
+	resp, err = c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #80 

This introduces slightly incompatible change:
- Now users who replaces `Client.HTTPClient` with their own client have to set timeout by themselves

But in normal use cases this doesn't affect.