### PR TITLE
Fix go vet and test with Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.10.x
 - 1.11.x
 - 1.12.x
 env: PATH=/home/travis/gopath/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
 - 1.10.x
 - 1.11.x
+- 1.12.x
 env: PATH=/home/travis/gopath/bin:$PATH
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ testdeps:
 
 LINT_RET = .golint.txt
 lint: testdeps
-	go tool vet .
+	go vet .
 	rm -f $(LINT_RET)
 	golint ./... | tee $(LINT_RET)
 	test ! -s $(LINT_RET)


### PR DESCRIPTION
go tool vet is no longer available with Go 1.12