### PR TITLE
remove 'omitempty' option from arrays of CreateHostParam's member

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -85,9 +85,9 @@ type CreateHostParam struct {
 	Name             string        `json:"name"`
 	DisplayName      string        `json:"displayName,omitempty"`
 	Meta             HostMeta      `json:"meta"`
-	Interfaces       []Interface   `json:"interfaces,omitempty"`
-	RoleFullnames    []string      `json:"roleFullnames,omitempty"`
-	Checks           []CheckConfig `json:"checks,omitempty"`
+	Interfaces       []Interface   `json:"interfaces"`
+	RoleFullnames    []string      `json:"roleFullnames"`
+	Checks           []CheckConfig `json:"checks"`
 	CustomIdentifier string        `json:"customIdentifier,omitempty"`
 }
 


### PR DESCRIPTION
In `CreateHostParam.Checks`, Mackerel distinguishes between nil and empty array.