### PR TITLE
add PrioritizedLogger interface for prioritized logging events

### DIFF
--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -2,9 +2,12 @@ package mackerel
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -76,4 +79,99 @@ func TestLogger(t *testing.T) {
 	if !strings.HasPrefix(s, "<api>") || !strings.HasSuffix(s, "OK") {
 		t.Errorf("verbose log should match /<api>.*OK/; but %s", s)
 	}
+}
+
+type fakeLogger struct {
+	w io.Writer
+}
+
+func (p *fakeLogger) Tracef(format string, v ...interface{}) {
+	fmt.Fprintf(p.w, format, v...)
+}
+func (p *fakeLogger) Debugf(format string, v ...interface{})   {}
+func (p *fakeLogger) Infof(format string, v ...interface{})    {}
+func (p *fakeLogger) Warningf(format string, v ...interface{}) {}
+func (p *fakeLogger) Errorf(format string, v ...interface{})   {}
+
+func TestPrivateTracef(t *testing.T) {
+	var (
+		stdbuf bytes.Buffer
+		logbuf bytes.Buffer
+		pbuf   bytes.Buffer
+	)
+	log.SetOutput(&stdbuf)
+	defer log.SetOutput(os.Stderr)
+	oflags := log.Flags()
+	defer log.SetFlags(oflags)
+	log.SetFlags(0)
+
+	msg := "test\n"
+	t.Run("Logger+PrioritizedLogger", func(t *testing.T) {
+		var c Client
+		c.Logger = log.New(&logbuf, "", 0)
+		c.PrioritizedLogger = &fakeLogger{w: &pbuf}
+		c.tracef(msg)
+		if s := stdbuf.String(); s != "" {
+			t.Errorf("tracef(%q): log.Printf(%q); want %q", msg, s, "")
+		}
+		if s := logbuf.String(); s != msg {
+			t.Errorf("tracef(%q): Logger.Printf(%q); want %q", msg, s, msg)
+		}
+		if s := pbuf.String(); s != msg {
+			t.Errorf("tracef(%q): PrioritizedLogger.Tracef(%q); want %q", msg, s, msg)
+		}
+	})
+
+	stdbuf.Reset()
+	logbuf.Reset()
+	pbuf.Reset()
+	t.Run("Logger", func(t *testing.T) {
+		var c Client
+		c.Logger = log.New(&logbuf, "", 0)
+		c.tracef(msg)
+		if s := stdbuf.String(); s != "" {
+			t.Errorf("tracef(%q): log.Printf(%q); want %q", msg, s, "")
+		}
+		if s := logbuf.String(); s != msg {
+			t.Errorf("tracef(%q): Logger.Printf(%q); want %q", msg, s, msg)
+		}
+		if s := pbuf.String(); s != "" {
+			t.Errorf("tracef(%q): PrioritizedLogger.Tracef(%q); want %q", msg, s, "")
+		}
+	})
+
+	stdbuf.Reset()
+	logbuf.Reset()
+	pbuf.Reset()
+	t.Run("PrioritizedLogger", func(t *testing.T) {
+		var c Client
+		c.PrioritizedLogger = &fakeLogger{w: &pbuf}
+		c.tracef(msg)
+		if s := stdbuf.String(); s != "" {
+			t.Errorf("tracef(%q): log.Printf(%q); want %q", msg, s, "")
+		}
+		if s := logbuf.String(); s != "" {
+			t.Errorf("tracef(%q): Logger.Printf(%q); want %q", msg, s, "")
+		}
+		if s := pbuf.String(); s != msg {
+			t.Errorf("tracef(%q): PrioritizedLogger.Tracef(%q); want %q", msg, s, msg)
+		}
+	})
+
+	stdbuf.Reset()
+	logbuf.Reset()
+	pbuf.Reset()
+	t.Run("default", func(t *testing.T) {
+		var c Client
+		c.tracef(msg)
+		if s := stdbuf.String(); s != msg {
+			t.Errorf("tracef(%q): log.Printf(%q); want %q", msg, s, msg)
+		}
+		if s := logbuf.String(); s != "" {
+			t.Errorf("tracef(%q): Logger.Printf(%q); want %q", msg, s, "")
+		}
+		if s := pbuf.String(); s != "" {
+			t.Errorf("tracef(%q): PrioritizedLogger.Tracef(%q); want %q", msg, s, "")
+		}
+	})
 }


### PR DESCRIPTION
I added `PrioritizedLogger` interface, then added * PrioritizedLogger* field into *Client*.

In few days ago, I added custom logging by #89.
However, current implementation of *mackerel-agent* uses a library that handles prioritized logging events.

Therefore I considered.

1. If `PrioritizedLogger` is set, then events per priorities will passed to appropriate method of `PrioritizedLogger` (such as `Tracef`)
2. If `Logger` is set, then all events will passed to `Logger.Printf`
3. If both `Logger` and `PrioritizedLogger` is nil, then all events will passed to `log.Printf`

The rule 3 is needed for backward compatibility; see #89