### PR TITLE
Match dashboards.go to the current API.  ( GET only )

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -11,30 +11,30 @@ import (
 Legacy
 {
   "dashboards": [
-	{
-	  "id": "2c5bLca8d",
-	  "title": "My Dashboard",
-	  "bodyMarkdown": "# A test dashboard",
-	  "urlPath": "2u4PP3TJqbu",
-	  "createdAt": 1439346145003,
-	  "updatedAt": 1439346145003,
-	  "isLegacy": true
-	}
+    {
+       "id": "2c5bLca8d",
+       "title": "My Dashboard",
+       "bodyMarkdown": "# A test dashboard",
+       "urlPath": "2u4PP3TJqbu",
+       "createdAt": 1439346145003,
+       "updatedAt": 1439346145003,
+       "isLegacy": true
+    }
   ]
 }
 
 Current
 {
-	"dashboards": [
-		{
-			"id":        "2c5bLca8e",
-			"title":     "My Custom Dashboard(Current)",
-			"urlPath":   "2u4PP3TJqbv",
-			"createdAt": 1552909732,
-			"updatedAt": 1552992837,
-			"memo":      "A test Current Dashboard"
-		}
-	]
+  "dashboards": [
+    {
+      "id":        "2c5bLca8e",
+      "title":     "My Custom Dashboard(Current)",
+      "urlPath":   "2u4PP3TJqbv",
+      "createdAt": 1552909732,
+      "updatedAt": 1552992837,
+      "memo":      "A test Current Dashboard"
+    }
+  ]
 }
 */
 
@@ -42,13 +42,13 @@ Current
 `/dashboards/${ID}` Response`
 Legacy
 {
-	"id": "2c5bLca8d",
-	"title": "My Dashboard",
-	"bodyMarkdown": "# A test dashboard",
-	"urlPath": "2u4PP3TJqbu",
-	"createdAt": 1439346145003,
-	"updatedAt": 1439346145003,
-	"isLegacy": true
+  "id": "2c5bLca8d",
+  "title": "My Dashboard",
+  "bodyMarkdown": "# A test dashboard",
+  "urlPath": "2u4PP3TJqbu",
+  "createdAt": 1439346145003,
+  "updatedAt": 1439346145003,
+  "isLegacy": true
 }
 Current
 {

--- a/dashboards.go
+++ b/dashboards.go
@@ -29,6 +29,8 @@ type Dashboard struct {
 	URLPath      string `json:"urlPath,omitempty"`
 	CreatedAt    int64  `json:"createdAt,omitempty"`
 	UpdatedAt    int64  `json:"updatedAt,omitempty"`
+	IsLegacy     bool   `json:"isLegacy,omitempty"`
+	Memo         string `json:"memo,omitempty"`
 }
 
 // FindDashboards find dashboards

--- a/dashboards.go
+++ b/dashboards.go
@@ -45,14 +45,20 @@ type Widget struct {
 
 // Metric information
 type Metric struct {
+	Type string `json:"type,omitempty"`
 }
 
 // Graph information
 type Graph struct {
+	Type string `json:"type,omitempty"`
 }
 
 // Layout information
 type Layout struct {
+	X      int16 `json:"x,omitempty"`
+	Y      int16 `json:"y,omitempty"`
+	Width  int16 `json:"width,omitempty"`
+	Height int16 `json:"height,omitempty"`
 }
 
 // FindDashboards find dashboards

--- a/dashboards.go
+++ b/dashboards.go
@@ -118,13 +118,13 @@ type Dashboard struct {
 
 // Widget information
 type Widget struct {
-	Type     string   `json:"type,omitempty"`
-	Title    string   `json:"title,omitempty"`
-	Metric   []Metric `json:"metric,omitempty"`
-	Graph    []Graph  `json:"graph,omitempty"`
-	Layout   []Layout `json:"layout,omitempty"`
-	Markdown string   `json:"markdown,omitempty"`
-	Range    []Range  `json:"range,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Metric   Metric `json:"metric,omitempty"`
+	Graph    Graph  `json:"graph,omitempty"`
+	Layout   Layout `json:"layout,omitempty"`
+	Markdown string `json:"markdown,omitempty"`
+	Range    Range  `json:"range,omitempty"`
 }
 
 // Metric information
@@ -158,10 +158,10 @@ type Range struct {
 
 // Layout information
 type Layout struct {
-	X      uint8  `json:"x,omitempty"`
-	Y      uint8  `json:"y,omitempty"`
-	Width  uint16 `json:"width,omitempty"`
-	Height uint16 `json:"height,omitempty"`
+	X      int64 `json:"x,omitempty"`
+	Y      int64 `json:"y,omitempty"`
+	Width  int64 `json:"width,omitempty"`
+	Height int64 `json:"height,omitempty"`
 }
 
 // FindDashboards find dashboards

--- a/dashboards.go
+++ b/dashboards.go
@@ -106,19 +106,19 @@ Current
 // Dashboard information
 type Dashboard struct {
 	// Common to legacy dashboard and current dashboard
-	ID           string   `json:"id,omitempty"`
-	Title        string   `json:"title,omitempty"`
-	URLPath      string   `json:"urlPath,omitempty"`
-	CreatedAt    int64    `json:"createdAt,omitempty"`
-	UpdatedAt    int64    `json:"updatedAt,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Title     string `json:"title,omitempty"`
+	URLPath   string `json:"urlPath,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+	UpdatedAt int64  `json:"updatedAt,omitempty"`
 
 	// current dashboard
 	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
 	Widgets      []Widget `json:"widgets,omitenpty"`
 
 	// legacy dashboard
-	IsLegacy     bool     `json:"isLegacy,omitempty"`
-	Memo         string   `json:"memo,omitempty"`
+	IsLegacy bool   `json:"isLegacy,omitempty"`
+	Memo     string `json:"memo,omitempty"`
 }
 
 // Widget information

--- a/dashboards.go
+++ b/dashboards.go
@@ -113,12 +113,12 @@ type Dashboard struct {
 	UpdatedAt int64  `json:"updatedAt,omitempty"`
 
 	// current dashboard
-	Memo     string `json:"memo,omitempty"`
-	Widgets      []Widget `json:"widgets,omitenpty"`
+	Memo    string   `json:"memo,omitempty"`
+	Widgets []Widget `json:"widgets,omitenpty"`
 
 	// legacy dashboard
-	IsLegacy bool   `json:"isLegacy,omitempty"`
-	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
+	IsLegacy     bool   `json:"isLegacy,omitempty"`
+	BodyMarkDown string `json:"bodyMarkdown,omitempty"`
 }
 
 // Widget information

--- a/dashboards.go
+++ b/dashboards.go
@@ -113,12 +113,12 @@ type Dashboard struct {
 	UpdatedAt int64  `json:"updatedAt,omitempty"`
 
 	// current dashboard
-	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
+	Memo     string `json:"memo,omitempty"`
 	Widgets      []Widget `json:"widgets,omitenpty"`
 
 	// legacy dashboard
 	IsLegacy bool   `json:"isLegacy,omitempty"`
-	Memo     string `json:"memo,omitempty"`
+	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
 }
 
 // Widget information

--- a/dashboards.go
+++ b/dashboards.go
@@ -132,7 +132,7 @@ type Metric struct {
 	Type        string `json:"type,omitempty"`
 	HostID      string `json:"hostId,omitempty"`
 	Name        string `json:"name,omitempty"`
-	ServiceName string `json:"seriviceName,omitempty"`
+	ServiceName string `json:"serviceName,omitempty"`
 	Expression  string `json:"expression,omitempty"`
 }
 

--- a/dashboards.go
+++ b/dashboards.go
@@ -105,15 +105,20 @@ Current
 
 // Dashboard information
 type Dashboard struct {
+	// Common to legacy dashboard and current dashboard
 	ID           string   `json:"id,omitempty"`
 	Title        string   `json:"title,omitempty"`
 	URLPath      string   `json:"urlPath,omitempty"`
 	CreatedAt    int64    `json:"createdAt,omitempty"`
 	UpdatedAt    int64    `json:"updatedAt,omitempty"`
-	IsLegacy     bool     `json:"isLegacy,omitempty"`
-	Memo         string   `json:"memo,omitempty"`
+
+	// current dashboard
 	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
 	Widgets      []Widget `json:"widgets,omitenpty"`
+
+	// legacy dashboard
+	IsLegacy     bool     `json:"isLegacy,omitempty"`
+	Memo         string   `json:"memo,omitempty"`
 }
 
 // Widget information

--- a/dashboards.go
+++ b/dashboards.go
@@ -118,21 +118,42 @@ type Dashboard struct {
 
 // Widget information
 type Widget struct {
-	Type   string   `json:"type,omitempty"`
-	Title  string   `json:"title,omitempty"`
-	Metric []Metric `json:"metric,omitempty"`
-	Graph  []Graph  `json:"graph,omitempty"`
-	Layout []Layout `json:"layout,omitempty"`
+	Type     string   `json:"type,omitempty"`
+	Title    string   `json:"title,omitempty"`
+	Metric   []Metric `json:"metric,omitempty"`
+	Graph    []Graph  `json:"graph,omitempty"`
+	Layout   []Layout `json:"layout,omitempty"`
+	Markdown string   `json:"markdown,omitempty"`
+	Range    []Range  `json:"range,omitempty"`
 }
 
 // Metric information
 type Metric struct {
-	Type string `json:"type,omitempty"`
+	Type        string `json:"type,omitempty"`
+	HostID      string `json:"hostId,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ServiceName string `json:"seriviceName,omitempty"`
+	Expression  string `json:"expression,omitempty"`
 }
 
 // Graph information
 type Graph struct {
-	Type string `json:"type,omitempty"`
+	Type         string `json:"type,omitempty"`
+	HostID       string `json:"hostId,omitempty"`
+	Name         string `json:"name,omitempty"`
+	RoleFullName string `json:"roleFullname,omitempty"`
+	ServiceName  string `json:"seriviceName,omitempty"`
+	Expression   string `json:"expression,omitempty"`
+	IsStacked    bool   `json:"isStacked,omitempty"`
+}
+
+// Range information
+type Range struct {
+	Type   string `json:"type,omitempty"`
+	Period int64  `json:"period,omitempty"`
+	Offset int64  `json:"offset,omitempty"`
+	Start  int64  `json:"start,omitempty"`
+	End    int64  `json:"end,omitempty"`
 }
 
 // Layout information

--- a/dashboards.go
+++ b/dashboards.go
@@ -23,14 +23,36 @@ import (
 
 // Dashboard information
 type Dashboard struct {
-	ID           string `json:"id,omitempty"`
-	Title        string `json:"title,omitempty"`
-	BodyMarkDown string `json:"bodyMarkdown,omitempty"`
-	URLPath      string `json:"urlPath,omitempty"`
-	CreatedAt    int64  `json:"createdAt,omitempty"`
-	UpdatedAt    int64  `json:"updatedAt,omitempty"`
-	IsLegacy     bool   `json:"isLegacy,omitempty"`
-	Memo         string `json:"memo,omitempty"`
+	ID           string   `json:"id,omitempty"`
+	Title        string   `json:"title,omitempty"`
+	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
+	URLPath      string   `json:"urlPath,omitempty"`
+	CreatedAt    int64    `json:"createdAt,omitempty"`
+	UpdatedAt    int64    `json:"updatedAt,omitempty"`
+	IsLegacy     bool     `json:"isLegacy,omitempty"`
+	Memo         string   `json:"memo,omitempty"`
+	Widgets      []Widget `json:"widgets,omitenpty"`
+}
+
+// Widget information
+type Widget struct {
+	Type   string   `json:"type,omitempty"`
+	Title  string   `json:"title,omitempty"`
+	Metric []Metric `json:"metric,omitempty"`
+	Graph  []Graph  `json:"graph,omitempty"`
+	Layout []Layout `json:"layout,omitempty"`
+}
+
+// Metric information
+type Metric struct {
+}
+
+// Graph information
+type Graph struct {
+}
+
+// Layout information
+type Layout struct {
 }
 
 // FindDashboards find dashboards

--- a/dashboards.go
+++ b/dashboards.go
@@ -107,12 +107,12 @@ Current
 type Dashboard struct {
 	ID           string   `json:"id,omitempty"`
 	Title        string   `json:"title,omitempty"`
-	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
 	URLPath      string   `json:"urlPath,omitempty"`
 	CreatedAt    int64    `json:"createdAt,omitempty"`
 	UpdatedAt    int64    `json:"updatedAt,omitempty"`
 	IsLegacy     bool     `json:"isLegacy,omitempty"`
 	Memo         string   `json:"memo,omitempty"`
+	BodyMarkDown string   `json:"bodyMarkdown,omitempty"`
 	Widgets      []Widget `json:"widgets,omitenpty"`
 }
 
@@ -120,18 +120,18 @@ type Dashboard struct {
 type Widget struct {
 	Type     string `json:"type,omitempty"`
 	Title    string `json:"title,omitempty"`
+	Layout   Layout `json:"layout,omitempty"`
 	Metric   Metric `json:"metric,omitempty"`
 	Graph    Graph  `json:"graph,omitempty"`
-	Layout   Layout `json:"layout,omitempty"`
-	Markdown string `json:"markdown,omitempty"`
 	Range    Range  `json:"range,omitempty"`
+	Markdown string `json:"markdown,omitempty"`
 }
 
 // Metric information
 type Metric struct {
 	Type        string `json:"type,omitempty"`
-	HostID      string `json:"hostId,omitempty"`
 	Name        string `json:"name,omitempty"`
+	HostID      string `json:"hostId,omitempty"`
 	ServiceName string `json:"serviceName,omitempty"`
 	Expression  string `json:"expression,omitempty"`
 }
@@ -139,12 +139,12 @@ type Metric struct {
 // Graph information
 type Graph struct {
 	Type         string `json:"type,omitempty"`
-	HostID       string `json:"hostId,omitempty"`
 	Name         string `json:"name,omitempty"`
+	HostID       string `json:"hostId,omitempty"`
 	RoleFullName string `json:"roleFullname,omitempty"`
+	IsStacked    bool   `json:"isStacked,omitempty"`
 	ServiceName  string `json:"serviceName,omitempty"`
 	Expression   string `json:"expression,omitempty"`
-	IsStacked    bool   `json:"isStacked,omitempty"`
 }
 
 // Range information

--- a/dashboards.go
+++ b/dashboards.go
@@ -7,6 +7,8 @@ import (
 )
 
 /*
+`/dashboards` Response
+Legacy
 {
   "dashboards": [
 	{
@@ -15,8 +17,88 @@ import (
 	  "bodyMarkdown": "# A test dashboard",
 	  "urlPath": "2u4PP3TJqbu",
 	  "createdAt": 1439346145003,
-	  "updatedAt": 1439346145003
+	  "updatedAt": 1439346145003,
+	  "isLegacy": true
 	}
+  ]
+}
+
+Current
+{
+	"dashboards": [
+		{
+			"id":        "2c5bLca8e",
+			"title":     "My Custom Dashboard(Current)",
+			"urlPath":   "2u4PP3TJqbv",
+			"createdAt": 1552909732,
+			"updatedAt": 1552992837,
+			"memo":      "A test Current Dashboard"
+		}
+	]
+}
+*/
+
+/*
+`/dashboards/${ID}` Response`
+Legacy
+{
+	"id": "2c5bLca8d",
+	"title": "My Dashboard",
+	"bodyMarkdown": "# A test dashboard",
+	"urlPath": "2u4PP3TJqbu",
+	"createdAt": 1439346145003,
+	"updatedAt": 1439346145003,
+	"isLegacy": true
+}
+Current
+{
+  "id": "2c5bLca8e",
+  "createdAt": 1552909732,
+  "updatedAt": 1552992837,
+  "title": "My Custom Dashboard(Current),
+  "urlPath": "2u4PP3TJqbv",
+  "memo": "A test Current Dashboard",
+  "widgets": [
+    {
+      "type": "markdown",
+      "title": "markdown",
+      "markdown": "# body",
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 24,
+        "height": 3
+      }
+    },
+    {
+      "type": "graph",
+      "title": "graph",
+      "graph": {
+        "type": "host",
+        "hostId": "2u4PP3TJqbw",
+        "name": "loadavg.loadavg15"
+      },
+      "layout": {
+        "x": 0,
+        "y": 7,
+        "width": 8,
+        "height": 10
+      }
+    },
+    {
+      "type": "value",
+      "title": "value",
+      "metric": {
+        "type": "expression",
+        "expression": "alias(scale(\nsum(\n  group(\n    host(2u4PP3TJqbx,loadavg.*)\n  )\n),\n1\n), 'test')"
+      },
+      "layout": {
+        "x": 0,
+        "y": 17,
+        "width": 8,
+        "height": 5
+      }
+    }
   ]
 }
 */
@@ -55,10 +137,10 @@ type Graph struct {
 
 // Layout information
 type Layout struct {
-	X      int16 `json:"x,omitempty"`
-	Y      int16 `json:"y,omitempty"`
-	Width  int16 `json:"width,omitempty"`
-	Height int16 `json:"height,omitempty"`
+	X      uint8  `json:"x,omitempty"`
+	Y      uint8  `json:"y,omitempty"`
+	Width  uint16 `json:"width,omitempty"`
+	Height uint16 `json:"height,omitempty"`
 }
 
 // FindDashboards find dashboards

--- a/dashboards.go
+++ b/dashboards.go
@@ -142,7 +142,7 @@ type Graph struct {
 	HostID       string `json:"hostId,omitempty"`
 	Name         string `json:"name,omitempty"`
 	RoleFullName string `json:"roleFullname,omitempty"`
-	ServiceName  string `json:"seriviceName,omitempty"`
+	ServiceName  string `json:"serviceName,omitempty"`
 	Expression   string `json:"expression,omitempty"`
 	IsStacked    bool   `json:"isStacked,omitempty"`
 }

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -241,7 +241,7 @@ func TestFindDashboard(t *testing.T) {
 		t.Error("request sends json including memo but:", dashboard)
 	}
 
-	// Widget Test : Markdown
+	// Widget Test : Widget(Common) && Markdown && Layout(Common)
 	if dashboard.Widgets[0].Type != "markdown" {
 		t.Error("request sends json including widgets.type but:", dashboard)
 	}
@@ -268,6 +268,29 @@ func TestFindDashboard(t *testing.T) {
 
 	if dashboard.Widgets[0].Layout.Height != 3 {
 		t.Error("request sends json including widgets.layout.height  but:", dashboard)
+	}
+
+	// Widget Test : Graph ( && Host Type)
+	if dashboard.Widgets[1].Graph.Type != "host" {
+		t.Error("request sends json including widgets.graph.type but:", dashboard)
+	}
+
+	if dashboard.Widgets[1].Graph.HostID != "2u4PP3TJqbw" {
+		t.Error("request sends json including widgets.graph.hostId but:", dashboard)
+	}
+
+	if dashboard.Widgets[1].Graph.Name != "loadavg.loadavg15" {
+		t.Error("request sends json including widgets.graph.name but:", dashboard)
+	}
+
+	// Widget Test : Metric ( && Expression Type)
+
+	if dashboard.Widgets[2].Metric.Type != "expression" {
+		t.Error("request sends json including widgets.metric.type but:", dashboard)
+	}
+
+	if dashboard.Widgets[2].Metric.Expression != "alias(scale(\nsum(\n  group(\n    host(2u4PP3TJqbx,loadavg.*)\n  )\n),\n1\n), 'test')" {
+		t.Error("request sends json including widgets.metric.expression but:", dashboard)
 	}
 
 }

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -81,7 +81,7 @@ func TestFindDashboards(t *testing.T) {
 	}
 }
 
-func TestFindDashboard(t *testing.T) {
+func TestFindDashboardForLegacy(t *testing.T) {
 
 	testID := "2c5bLca8d"
 
@@ -93,11 +93,12 @@ func TestFindDashboard(t *testing.T) {
 		respJSON, _ := json.Marshal(
 			map[string]interface{}{
 				"id":           "2c5bLca8d",
-				"title":        "My Dashboard",
-				"bodyMarkDown": "# A test dashboard",
+				"title":        "My Dashboard(Legacy)",
+				"bodyMarkDown": "# A test Legacy dashboard",
 				"urlPath":      "2u4PP3TJqbu",
 				"createdAt":    1439346145003,
 				"updatedAt":    1439346145003,
+				"isLegacy":     true,
 			},
 		)
 
@@ -117,11 +118,11 @@ func TestFindDashboard(t *testing.T) {
 		t.Error("request sends json including id but: ", dashboard)
 	}
 
-	if dashboard.Title != "My Dashboard" {
+	if dashboard.Title != "My Dashboard(Legacy)" {
 		t.Error("request sends json including title but: ", dashboard)
 	}
 
-	if dashboard.BodyMarkDown != "# A test dashboard" {
+	if dashboard.BodyMarkDown != "# A test Legacy dashboard" {
 		t.Error("request sends json including bodyMarkDown but: ", dashboard)
 	}
 
@@ -135,6 +136,67 @@ func TestFindDashboard(t *testing.T) {
 
 	if dashboard.UpdatedAt != 1439346145003 {
 		t.Error("request sends json including updatedAt but: ", dashboard)
+	}
+
+	if dashboard.IsLegacy != true {
+		t.Error("request sends json including isLegacy but:", dashboard)
+	}
+}
+
+func TestFindDashboard(t *testing.T) {
+
+	testID := "2c5bLca8d"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != fmt.Sprintf("/api/v0/dashboards/%s", testID) {
+			t.Error("request URL should be /api/v0/dashboards/<ID> but: ", req.URL.Path)
+		}
+
+		respJSON, _ := json.Marshal(
+			map[string]interface{}{
+				"id":        "2c5bLca8e",
+				"title":     "My Custom Dashboard(Current)",
+				"urlPath":   "2u4PP3TJqbv",
+				"createdAt": 1552909732,
+				"updatedAt": 1552992837,
+				"memo":      "A test Current Dashboard",
+			},
+		)
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	dashboard, err := client.FindDashboard(testID)
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if dashboard.ID != "2c5bLca8e" {
+		t.Error("request sends json including id but: ", dashboard)
+	}
+
+	if dashboard.Title != "My Custom Dashboard(Current)" {
+		t.Error("request sends json including title but: ", dashboard)
+	}
+
+	if dashboard.URLPath != "2u4PP3TJqbv" {
+		t.Error("request sends json including urlpath but: ", dashboard)
+	}
+
+	if dashboard.CreatedAt != 1552909732 {
+		t.Error("request sends json including createdAt but: ", dashboard)
+	}
+
+	if dashboard.UpdatedAt != 1552992837 {
+		t.Error("request sends json including updatedAt but: ", dashboard)
+	}
+
+	if dashboard.Memo != "A test Current Dashboard" {
+		t.Error("request sends json including isLegacy but:", dashboard)
 	}
 }
 

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -161,7 +161,7 @@ func TestFindDashboard(t *testing.T) {
 				"urlPath":   "2u4PP3TJqbv",
 				"memo":      "A test Current Dashboard",
 				"widgets": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"type":     "markdown",
 						"title":    "markdown",
 						"markdown": "# body",
@@ -172,7 +172,7 @@ func TestFindDashboard(t *testing.T) {
 							"height": 3,
 						},
 					},
-					map[string]interface{}{
+					{
 						"type":  "graph",
 						"title": "graph",
 						"graph": map[string]interface{}{
@@ -187,7 +187,7 @@ func TestFindDashboard(t *testing.T) {
 							"height": 10,
 						},
 					},
-					map[string]interface{}{
+					{
 						"type":  "value",
 						"title": "value",
 						"metric": map[string]interface{}{

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -238,8 +238,9 @@ func TestFindDashboard(t *testing.T) {
 	}
 
 	if dashboard.Memo != "A test Current Dashboard" {
-		t.Error("request sends json including isLegacy but:", dashboard)
+		t.Error("request sends json including memo but:", dashboard)
 	}
+
 }
 
 func TestCreateDashboard(t *testing.T) {

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -19,15 +19,23 @@ func TestFindDashboards(t *testing.T) {
 			"dashboards": {
 				{
 					"id":           "2c5bLca8d",
-					"title":        "My Dashboard",
-					"bodyMarkDown": "# A test dashboard",
+					"title":        "My Dashboard(Legacy)",
+					"bodyMarkDown": "# A test Legacy dashboard",
 					"urlPath":      "2u4PP3TJqbu",
 					"createdAt":    1439346145003,
 					"updatedAt":    1439346145003,
+					"isLegacy":     true,
+				},
+				{
+					"id":        "2c5bLca8e",
+					"title":     "My Custom Dashboard(Current)",
+					"urlPath":   "2u4PP3TJqbv",
+					"createdAt": 1552909732,
+					"updatedAt": 1552992837,
+					"memo":      "A test Current Dashboard",
 				},
 			},
 		})
-
 		res.Header()["Content-Type"] = []string{"application/json"}
 		fmt.Fprint(res, string(respJSON))
 	}))
@@ -44,11 +52,11 @@ func TestFindDashboards(t *testing.T) {
 		t.Error("request sends json including id but: ", dashboards[0])
 	}
 
-	if dashboards[0].Title != "My Dashboard" {
+	if dashboards[0].Title != "My Dashboard(Legacy)" {
 		t.Error("request sends json including title but: ", dashboards[0])
 	}
 
-	if dashboards[0].BodyMarkDown != "# A test dashboard" {
+	if dashboards[0].BodyMarkDown != "# A test Legacy dashboard" {
 		t.Error("request sends json including bodyMarkDown but: ", dashboards[0])
 	}
 
@@ -62,6 +70,10 @@ func TestFindDashboards(t *testing.T) {
 
 	if dashboards[0].UpdatedAt != 1439346145003 {
 		t.Error("request sends json including updatedAt but: ", dashboards[0])
+	}
+
+	if dashboards[0].IsLegacy != true {
+		t.Error("request sends json including IsLegacy but: ", dashboards[0])
 	}
 }
 

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -73,7 +73,11 @@ func TestFindDashboards(t *testing.T) {
 	}
 
 	if dashboards[0].IsLegacy != true {
-		t.Error("request sends json including IsLegacy but: ", dashboards[0])
+		t.Error("request sends json including isLegacy but: ", dashboards[0])
+	}
+
+	if dashboards[1].Memo != "A test Current Dashboard" {
+		t.Error("request sends json including memo but: ", dashboards[1])
 	}
 }
 

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -163,7 +163,7 @@ func TestFindDashboard(t *testing.T) {
 				"widgets": []map[string]interface{}{
 					{
 						"type":     "markdown",
-						"title":    "markdown",
+						"title":    "markdown_widget",
 						"markdown": "# body",
 						"layout": map[string]interface{}{
 							"x":      0,
@@ -174,7 +174,7 @@ func TestFindDashboard(t *testing.T) {
 					},
 					{
 						"type":  "graph",
-						"title": "graph",
+						"title": "graph_widget",
 						"graph": map[string]interface{}{
 							"type":   "host",
 							"hostId": "2u4PP3TJqbw",
@@ -189,7 +189,7 @@ func TestFindDashboard(t *testing.T) {
 					},
 					{
 						"type":  "value",
-						"title": "value",
+						"title": "value_widget",
 						"metric": map[string]interface{}{
 							"type":       "expression",
 							"expression": "alias(scale(\nsum(\n  group(\n    host(2u4PP3TJqbx,loadavg.*)\n  )\n),\n1\n), 'test')",
@@ -239,6 +239,35 @@ func TestFindDashboard(t *testing.T) {
 
 	if dashboard.Memo != "A test Current Dashboard" {
 		t.Error("request sends json including memo but:", dashboard)
+	}
+
+	// Widget Test : Markdown
+	if dashboard.Widgets[0].Type != "markdown" {
+		t.Error("request sends json including widgets.type but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Title != "markdown_widget" {
+		t.Error("request sends json including widgets.title but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Markdown != "# body" {
+		t.Error("request sends json including widgets.markdown but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Layout.X != 0 {
+		t.Error("request sends json including widgets.layout.x but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Layout.Y != 0 {
+		t.Error("request sends json including widgets.layout.y  but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Layout.Width != 24 {
+		t.Error("request sends json including widgets.layout.width  but:", dashboard)
+	}
+
+	if dashboard.Widgets[0].Layout.Height != 3 {
+		t.Error("request sends json including widgets.layout.height  but:", dashboard)
 	}
 
 }


### PR DESCRIPTION
dashboards.go looked the same as before the concept of the traditional dashboards appeared.
It is impossible to get information about the new custom dashboard.

So I made a p-r for the new custom dashboard.
However, only GET is supported.

This is the first time I've worked on OSS using golang. I am sorry if I do not have enough.