### PR TITLE
Delete unnecessary string conversion of FindUsers

### DIFF
--- a/users.go
+++ b/users.go
@@ -21,7 +21,7 @@ type User struct {
 
 // FindUsers find users.
 func (c *Client) FindUsers() ([]*User, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/users")).String(), nil)
+	req, err := http.NewRequest("GET", c.urlFor("/api/v0/users").String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ref: https://mackerel.io/ja/api-docs/entry/invitations#list

Fix: https://github.com/mackerelio/mackerel-client-go/pull/97#discussion_r352430350


