### PR TITLE
Remove all useless Sprintf

### DIFF
--- a/services.go
+++ b/services.go
@@ -21,7 +21,7 @@ type CreateServiceParam struct {
 
 // FindServices finds services.
 func (c *Client) FindServices() ([]*Service, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/services")).String(), nil)
+	req, err := http.NewRequest("GET", c.urlFor("/api/v0/services").String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I found a useless `Sprintf` which has no format string, like below.

https://github.com/mackerelio/mackerel-client-go/pull/97#discussion_r352430350
https://github.com/mackerelio/mackerel-client-go/pull/98

So I remove this.

To find the `Sprintf` I ran this command :

```console
$ ag 'Sprintf(?!.+%)'
```