### PR TITLE
Implement Notification channel API methods

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -3,8 +3,14 @@ package mackerel
 // TODO
 
 // Channel represents a Mackerel notification channel.
+// ref. https://mackerel.io/api-docs/entry/channels
 type Channel struct {
-	ID   string `json:"id"`
+	ID string `json:"id"`
+	ChannelWithoutID
+}
+
+// ChannelWithoutID represents a Mackerel notification channel without the ID.
+type ChannelWithoutID struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 

--- a/channels.go
+++ b/channels.go
@@ -1,0 +1,3 @@
+package mackerel
+
+// TODO

--- a/channels.go
+++ b/channels.go
@@ -23,18 +23,21 @@ type ChannelWithoutID struct {
 	UserIDs []string `json:"userIds,omitempty"`
 
 	// Exists when the type is "slack"
-	Mentions struct {
-		OK       string `json:"ok,omitempty"`
-		Warning  string `json:"warning,omitempty"`
-		Critical string `json:"critical,omitempty"`
-	} `json:"mentions,omitempty"`
-	EnabledGraphImage bool `json:"enabledGraphImage,omitempty"`
+	Mentions          Mentions `json:"mentions,omitempty"`
+	EnabledGraphImage bool     `json:"enabledGraphImage,omitempty"`
 
 	// Exists when the type is "slack" or "webhook"
 	URL string `json:"url,omitempty"`
 
 	// Exists when the type is "email", "slack", or "webhook"
 	Events []string `json:"events,omitempty"`
+}
+
+// Mentions represents the structure used for slack channel mentions
+type Mentions struct {
+	OK       string `json:"ok,omitempty"`
+	Warning  string `json:"warning,omitempty"`
+	Critical string `json:"critical,omitempty"`
 }
 
 // ListChannels requests the channels API and returns a list of Channel

--- a/channels.go
+++ b/channels.go
@@ -9,7 +9,8 @@ import (
 // Channel represents a Mackerel notification channel.
 // ref. https://mackerel.io/api-docs/entry/channels
 type Channel struct {
-	ID string `json:"id"`
+	// ID is excluded when used to call CreateChannel
+	ID string `json:"id,omitempty"`
 
 	Name string `json:"name"`
 	Type string `json:"type"`

--- a/channels.go
+++ b/channels.go
@@ -1,3 +1,28 @@
 package mackerel
 
 // TODO
+
+// Channel represents a Mackerel notification channel.
+type Channel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+
+	// Exists when the type is "email"
+	Emails  []string `json:"emails,omitempty"`
+	UserIDs []string `json:"userIds,omitempty"`
+
+	// Exists when the type is "slack"
+	Mentions struct {
+		OK       string `json:"ok,omitempty"`
+		Warning  string `json:"warning,omitempty"`
+		Critical string `json:"critical,omitempty"`
+	} `json:"mentions,omitempty"`
+	EnabledGraphImage bool `json:"enabledGraphImage,omitempty"`
+
+	// Exists when the type is "slack" or "webhook"
+	URL string `json:"url,omitempty"`
+
+	// Exists when the type is "email", "slack", or "webhook"
+	Events []string `json:"events,omitempty"`
+}

--- a/channels.go
+++ b/channels.go
@@ -20,8 +20,10 @@ type Channel struct {
 	UserIDs []string `json:"userIds,omitempty"`
 
 	// Exists when the type is "slack"
-	Mentions          Mentions `json:"mentions,omitempty"`
-	EnabledGraphImage bool     `json:"enabledGraphImage,omitempty"`
+	Mentions Mentions `json:"mentions,omitempty"`
+	// In order to support both 'not setting this field' and 'setting the field as false',
+	// this field needed to be *bool not bool.
+	EnabledGraphImage *bool `json:"enabledGraphImage,omitempty"`
 
 	// Exists when the type is "slack" or "webhook"
 	URL string `json:"url,omitempty"`

--- a/channels.go
+++ b/channels.go
@@ -16,8 +16,8 @@ type Channel struct {
 	Type string `json:"type"`
 
 	// Exists when the type is "email"
-	Emails  []string `json:"emails,omitempty"`
-	UserIDs []string `json:"userIds,omitempty"`
+	Emails  *[]string `json:"emails,omitempty"`
+	UserIDs *[]string `json:"userIds,omitempty"`
 
 	// Exists when the type is "slack"
 	Mentions Mentions `json:"mentions,omitempty"`
@@ -29,7 +29,7 @@ type Channel struct {
 	URL string `json:"url,omitempty"`
 
 	// Exists when the type is "email", "slack", or "webhook"
-	Events []string `json:"events,omitempty"`
+	Events *[]string `json:"events,omitempty"`
 }
 
 // Mentions represents the structure used for slack channel mentions

--- a/channels.go
+++ b/channels.go
@@ -10,11 +10,7 @@ import (
 // ref. https://mackerel.io/api-docs/entry/channels
 type Channel struct {
 	ID string `json:"id"`
-	CreateChannelParams
-}
 
-// CreateChannelParams represents a Mackerel notification channel to be used by CreateChannel.
-type CreateChannelParams struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 
@@ -63,7 +59,7 @@ func (c *Client) FindChannels() ([]*Channel, error) {
 }
 
 // CreateChannel requests the channels API with the given params to create a channel and returns the created channel.
-func (c *Client) CreateChannel(param *CreateChannelParams) (*Channel, error) {
+func (c *Client) CreateChannel(param *Channel) (*Channel, error) {
 	resp, err := c.PostJSON("/api/v0/channels", param)
 	defer closeResponse(resp)
 	if err != nil {

--- a/channels.go
+++ b/channels.go
@@ -10,11 +10,11 @@ import (
 // ref. https://mackerel.io/api-docs/entry/channels
 type Channel struct {
 	ID string `json:"id"`
-	ChannelWithoutID
+	CreateChannelParams
 }
 
-// ChannelWithoutID represents a Mackerel notification channel without the ID.
-type ChannelWithoutID struct {
+// CreateChannelParams represents a Mackerel notification channel to be used by CreateChannel.
+type CreateChannelParams struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 
@@ -63,7 +63,7 @@ func (c *Client) ListChannels() ([]*Channel, error) {
 }
 
 // CreateChannel requests the channels API with the given params to create a channel and returns the created channel.
-func (c *Client) CreateChannel(param *ChannelWithoutID) (*Channel, error) {
+func (c *Client) CreateChannel(param *CreateChannelParams) (*Channel, error) {
 	resp, err := c.PostJSON("/api/v0/channels", param)
 	defer closeResponse(resp)
 	if err != nil {

--- a/channels.go
+++ b/channels.go
@@ -40,8 +40,8 @@ type Mentions struct {
 	Critical string `json:"critical,omitempty"`
 }
 
-// ListChannels requests the channels API and returns a list of Channel
-func (c *Client) ListChannels() ([]*Channel, error) {
+// FindChannels requests the channels API and returns a list of Channel
+func (c *Client) FindChannels() ([]*Channel, error) {
 	req, err := http.NewRequest("GET", c.urlFor("/api/v0/channels").String(), nil)
 	if err != nil {
 		return nil, err

--- a/channels_test.go
+++ b/channels_test.go
@@ -1,11 +1,84 @@
 package mackerel
 
-// TODO: Write test and implementation for each of the following.
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
 
-// Getting Notification Channels
-//   GET /api/v0/channels
-// Registering Notification Channels
-//  POST /api/v0/channels
-// Deleting Notification Channels
-//  DELETE /api/v0/channels/<channelId>
-// https://mackerel.io/api-docs/entry/channels
+func TestListChannels(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/channels" {
+			t.Error("request URL should be /api/v0/channels but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string][]map[string]interface{}{
+			"channels": {
+				{
+					"id":      "abcdefabc",
+					"name":    "email channel",
+					"type":    "email",
+					"emails":  []string{"test@example.com", "test2@example.com"},
+					"userIds": []string{"1234", "2345"},
+					"events":  []string{"alert"},
+				},
+				{
+					"id":   "bcdefabcd",
+					"name": "slack channel",
+					"type": "slack",
+					"url":  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
+					"mentions": map[string]interface{}{
+						"ok":      "ok message",
+						"warning": "warning message",
+					},
+					"enabledGraphImage": true,
+					"events":            []string{"alert"},
+				},
+				{
+					"id":     "cdefabcde",
+					"name":   "webhook channel",
+					"type":   "webhook",
+					"url":    "http://example.com/webhook",
+					"events": []string{"alert"},
+				},
+				{
+					"id":   "defabcdef",
+					"name": "line channel",
+					"type": "line",
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	channels, err := client.ListChannels()
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if reflect.DeepEqual(channels[0].Emails, []string{"test@example.com", "test2@example.com"}) != true {
+		t.Errorf("Wrong data for emails: %v", channels[0].Emails)
+	}
+	if reflect.DeepEqual(channels[0].UserIDs, []string{"1234", "2345"}) != true {
+		t.Errorf("Wrong data for emails: %v", channels[0].UserIDs)
+	}
+
+	if channels[1].URL != "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX" {
+		t.Error("request sends json including URL but: ", channels[1])
+	}
+	if channels[2].URL != "http://example.com/webhook" {
+		t.Error("request sends json including URL but: ", channels[2])
+	}
+}

--- a/channels_test.go
+++ b/channels_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+// boolPointer is a helper function to initialize a bool pointer
+func boolPointer(b bool) *bool {
+	return &b
+}
+
 func TestFindChannels(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/api/v0/channels" {
@@ -167,17 +172,17 @@ func TestFindChannels(t *testing.T) {
 	if reflect.DeepEqual(channels[3].Mentions, Mentions{}) != true {
 		t.Error("request has mentions but: ", channels[3].Mentions)
 	}
-	if channels[0].EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	if channels[0].EnabledGraphImage != nil {
+		t.Error("request sends json including enabledGraphImage but: ", *(channels[0].EnabledGraphImage))
 	}
-	if !channels[1].EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	if !*(channels[1].EnabledGraphImage) {
+		t.Error("request sends json including enabledGraphImage but: ", *(channels[1].EnabledGraphImage))
 	}
-	if channels[2].EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	if channels[2].EnabledGraphImage != nil {
+		t.Error("request sends json including enabledGraphImage but: ", *(channels[2].EnabledGraphImage))
 	}
-	if channels[3].EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	if channels[3].EnabledGraphImage != nil {
+		t.Error("request sends json including enabledGraphImage but: ", *(channels[3].EnabledGraphImage))
 	}
 }
 
@@ -211,7 +216,7 @@ func TestCreateChannel(t *testing.T) {
 
 	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
 
-	channel, err := client.CreateChannel(&CreateChannelParams{
+	channel, err := client.CreateChannel(&Channel{
 		Name: "slack channel",
 		Type: "slack",
 		URL:  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
@@ -219,7 +224,7 @@ func TestCreateChannel(t *testing.T) {
 			OK:      "ok message",
 			Warning: "warning message",
 		},
-		EnabledGraphImage: true,
+		EnabledGraphImage: boolPointer(true),
 		Events:            []string{"alert"},
 	})
 
@@ -239,8 +244,8 @@ func TestCreateChannel(t *testing.T) {
 	if reflect.DeepEqual(channel.Mentions, Mentions{OK: "ok message", Warning: "warning message"}) != true {
 		t.Errorf("Wrong data for mentions: %v", channel.Mentions)
 	}
-	if !channel.EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channel.EnabledGraphImage)
+	if !*channel.EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", *channel.EnabledGraphImage)
 	}
 	if reflect.DeepEqual(channel.Events, []string{"alert"}) != true {
 		t.Errorf("Wrong data for events: %v", channel.Events)
@@ -296,8 +301,8 @@ func TestDeleteChannel(t *testing.T) {
 	if reflect.DeepEqual(channel.Mentions, Mentions{OK: "ok message", Warning: "warning message"}) != true {
 		t.Errorf("Wrong data for mentions: %v", channel.Mentions)
 	}
-	if !channel.EnabledGraphImage {
-		t.Error("request sends json including enabledGraphImage but: ", channel.EnabledGraphImage)
+	if !*channel.EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", *channel.EnabledGraphImage)
 	}
 	if reflect.DeepEqual(channel.Events, []string{"alert"}) != true {
 		t.Errorf("Wrong data for events: %v", channel.Events)

--- a/channels_test.go
+++ b/channels_test.go
@@ -1,0 +1,11 @@
+package mackerel
+
+// TODO: Write test and implementation for each of the following.
+
+// Getting Notification Channels
+//   GET /api/v0/channels
+// Registering Notification Channels
+//  POST /api/v0/channels
+// Deleting Notification Channels
+//  DELETE /api/v0/channels/<channelId>
+// https://mackerel.io/api-docs/entry/channels

--- a/channels_test.go
+++ b/channels_test.go
@@ -110,6 +110,7 @@ func TestCreateChannel(t *testing.T) {
 		}
 
 		respJSON, _ := json.Marshal(map[string]interface{}{
+			"id":   "abcdefabc",
 			"name": "slack channel",
 			"type": "slack",
 			"url":  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
@@ -128,7 +129,7 @@ func TestCreateChannel(t *testing.T) {
 
 	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
 
-	_, err := client.CreateChannel(&ChannelWithoutID{
+	channel, err := client.CreateChannel(&ChannelWithoutID{
 		Name: "slack channel",
 		Type: "slack",
 		URL:  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
@@ -142,5 +143,24 @@ func TestCreateChannel(t *testing.T) {
 
 	if err != nil {
 		t.Error("err should be nil but: ", err)
+	}
+
+	if channel.ID != "abcdefabc" {
+		t.Error("request sends json including ID but: ", channel.ID)
+	}
+	if channel.Name != "slack channel" {
+		t.Error("request sends json including name but: ", channel.Name)
+	}
+	if channel.URL != "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX" {
+		t.Error("request sends json including URL but: ", channel.URL)
+	}
+	if reflect.DeepEqual(channel.Mentions, Mentions{OK: "ok message", Warning: "warning message"}) != true {
+		t.Errorf("Wrong data for mentions: %v", channel.Mentions)
+	}
+	if !channel.EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", channel.EnabledGraphImage)
+	}
+	if reflect.DeepEqual(channel.Events, []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", channel.Events)
 	}
 }

--- a/channels_test.go
+++ b/channels_test.go
@@ -46,7 +46,7 @@ func TestListChannels(t *testing.T) {
 					"name":   "webhook channel",
 					"type":   "webhook",
 					"url":    "http://example.com/webhook",
-					"events": []string{"alert"},
+					"events": []string{"alertGroup"},
 				},
 				{
 					"id":   "defabcdef",
@@ -67,24 +67,82 @@ func TestListChannels(t *testing.T) {
 	if err != nil {
 		t.Error("err should be nil but: ", err)
 	}
+	if len(channels) != 4 {
+		t.Error("request has 4 channels but: ", len(channels))
+	}
 
+	if channels[0].ID != "abcdefabc" {
+		t.Error("request has ID but: ", channels[0].ID)
+	}
+	if channels[1].ID != "bcdefabcd" {
+		t.Error("request has ID but: ", channels[1].ID)
+	}
+	if channels[2].ID != "cdefabcde" {
+		t.Error("request has ID but: ", channels[2].ID)
+	}
+	if channels[3].ID != "defabcdef" {
+		t.Error("request has ID but: ", channels[3].ID)
+	}
+	if channels[0].Name != "email channel" {
+		t.Error("request has Name but: ", channels[0].Name)
+	}
+	if channels[1].Name != "slack channel" {
+		t.Error("request has Name but: ", channels[1].Name)
+	}
+	if channels[2].Name != "webhook channel" {
+		t.Error("request has Name but: ", channels[2].Name)
+	}
+	if channels[3].Name != "line channel" {
+		t.Error("request has Name but: ", channels[3].Name)
+	}
+	if channels[0].Type != "email" {
+		t.Error("request has Type but: ", channels[0].Type)
+	}
+	if channels[1].Type != "slack" {
+		t.Error("request has Type but: ", channels[1].Type)
+	}
+	if channels[2].Type != "webhook" {
+		t.Error("request has Type but: ", channels[2].Type)
+	}
+	if channels[3].Type != "line" {
+		t.Error("request has Type but: ", channels[3].Type)
+	}
 	if reflect.DeepEqual(channels[0].Emails, []string{"test@example.com", "test2@example.com"}) != true {
 		t.Errorf("Wrong data for emails: %v", channels[0].Emails)
 	}
+	if len(channels[1].Emails) > 0 {
+		t.Errorf("Wrong data for emails: %v", channels[1].Emails)
+	}
+	if len(channels[2].Emails) > 0 {
+		t.Errorf("Wrong data for emails: %v", channels[2].Emails)
+	}
+	if len(channels[3].Emails) > 0 {
+		t.Errorf("Wrong data for emails: %v", channels[3].Emails)
+	}
 	if reflect.DeepEqual(channels[0].UserIDs, []string{"1234", "2345"}) != true {
-		t.Errorf("Wrong data for emails: %v", channels[0].UserIDs)
+		t.Errorf("Wrong data for userIds: %v", channels[0].UserIDs)
 	}
-
-	if channels[1].Mentions.OK != "ok message" {
-		t.Error("request has mentions.ok but: ", channels[1].Mentions.OK)
+	if len(channels[1].UserIDs) > 0 {
+		t.Errorf("Wrong data for userIds: %v", channels[1].UserIDs)
 	}
-	if channels[1].Mentions.Warning != "warning message" {
-		t.Error("request has mentions.warning but: ", channels[1].Mentions.Warning)
+	if len(channels[2].UserIDs) > 0 {
+		t.Errorf("Wrong data for userIds: %v", channels[2].UserIDs)
 	}
-	if channels[1].Mentions.Critical != "" {
-		t.Error("request does not have mentions.critical but: ", channels[1].Mentions.Critical)
+	if len(channels[3].UserIDs) > 0 {
+		t.Errorf("Wrong data for userIds: %v", channels[3].UserIDs)
 	}
-
+	if reflect.DeepEqual(channels[0].Events, []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", channels[0].Events)
+	}
+	if reflect.DeepEqual(channels[1].Events, []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", channels[1].Events)
+	}
+	if reflect.DeepEqual(channels[2].Events, []string{"alertGroup"}) != true {
+		t.Errorf("Wrong data for events: %v", channels[2].Events)
+	}
+	if len(channels[3].Events) > 0 {
+		t.Errorf("Wrong data for events: %v", channels[3].Events)
+	}
 	if channels[0].URL != "" {
 		t.Error("request has no URL but: ", channels[0])
 	}
@@ -96,6 +154,30 @@ func TestListChannels(t *testing.T) {
 	}
 	if channels[3].URL != "" {
 		t.Error("request has no URL but: ", channels[3])
+	}
+	if reflect.DeepEqual(channels[0].Mentions, Mentions{}) != true {
+		t.Error("request has mentions but: ", channels[0].Mentions)
+	}
+	if reflect.DeepEqual(channels[1].Mentions, Mentions{OK: "ok message", Warning: "warning message"}) != true {
+		t.Error("request has mentions but: ", channels[1].Mentions)
+	}
+	if reflect.DeepEqual(channels[2].Mentions, Mentions{}) != true {
+		t.Error("request has mentions but: ", channels[2].Mentions)
+	}
+	if reflect.DeepEqual(channels[3].Mentions, Mentions{}) != true {
+		t.Error("request has mentions but: ", channels[3].Mentions)
+	}
+	if channels[0].EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	}
+	if !channels[1].EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	}
+	if channels[2].EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
+	}
+	if channels[3].EnabledGraphImage {
+		t.Error("request sends json including enabledGraphImage but: ", channels[0].EnabledGraphImage)
 	}
 }
 

--- a/channels_test.go
+++ b/channels_test.go
@@ -98,3 +98,49 @@ func TestListChannels(t *testing.T) {
 		t.Error("request has no URL but: ", channels[3])
 	}
 }
+
+func TestCreateChannel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/channels" {
+			t.Error("request URL should be /api/v0/channels but: ", req.URL.Path)
+		}
+
+		if req.Method != "POST" {
+			t.Error("request method should be POST but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"name": "slack channel",
+			"type": "slack",
+			"url":  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
+			"mentions": map[string]interface{}{
+				"ok":      "ok message",
+				"warning": "warning message",
+			},
+			"enabledGraphImage": true,
+			"events":            []string{"alert"},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	_, err := client.CreateChannel(&ChannelWithoutID{
+		Name: "slack channel",
+		Type: "slack",
+		URL:  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",
+		Mentions: Mentions{
+			OK:      "ok message",
+			Warning: "warning message",
+		},
+		EnabledGraphImage: true,
+		Events:            []string{"alert"},
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+}

--- a/channels_test.go
+++ b/channels_test.go
@@ -112,41 +112,41 @@ func TestFindChannels(t *testing.T) {
 	if channels[3].Type != "line" {
 		t.Error("request has Type but: ", channels[3].Type)
 	}
-	if reflect.DeepEqual(channels[0].Emails, []string{"test@example.com", "test2@example.com"}) != true {
-		t.Errorf("Wrong data for emails: %v", channels[0].Emails)
+	if reflect.DeepEqual(*(channels[0].Emails), []string{"test@example.com", "test2@example.com"}) != true {
+		t.Errorf("Wrong data for emails: %v", *(channels[0].Emails))
 	}
-	if len(channels[1].Emails) > 0 {
-		t.Errorf("Wrong data for emails: %v", channels[1].Emails)
+	if channels[1].Emails != nil {
+		t.Errorf("Wrong data for emails: %v", *(channels[1].Emails))
 	}
-	if len(channels[2].Emails) > 0 {
-		t.Errorf("Wrong data for emails: %v", channels[2].Emails)
+	if channels[2].Emails != nil {
+		t.Errorf("Wrong data for emails: %v", *(channels[2].Emails))
 	}
-	if len(channels[3].Emails) > 0 {
-		t.Errorf("Wrong data for emails: %v", channels[3].Emails)
+	if channels[3].Emails != nil {
+		t.Errorf("Wrong data for emails: %v", *(channels[3].Emails))
 	}
-	if reflect.DeepEqual(channels[0].UserIDs, []string{"1234", "2345"}) != true {
-		t.Errorf("Wrong data for userIds: %v", channels[0].UserIDs)
+	if reflect.DeepEqual(*(channels[0].UserIDs), []string{"1234", "2345"}) != true {
+		t.Errorf("Wrong data for userIds: %v", *(channels[0].UserIDs))
 	}
-	if len(channels[1].UserIDs) > 0 {
-		t.Errorf("Wrong data for userIds: %v", channels[1].UserIDs)
+	if channels[1].UserIDs != nil {
+		t.Errorf("Wrong data for userIds: %v", *(channels[1].UserIDs))
 	}
-	if len(channels[2].UserIDs) > 0 {
-		t.Errorf("Wrong data for userIds: %v", channels[2].UserIDs)
+	if channels[2].UserIDs != nil {
+		t.Errorf("Wrong data for userIds: %v", *(channels[2].UserIDs))
 	}
-	if len(channels[3].UserIDs) > 0 {
-		t.Errorf("Wrong data for userIds: %v", channels[3].UserIDs)
+	if channels[3].UserIDs != nil {
+		t.Errorf("Wrong data for userIds: %v", *(channels[3].UserIDs))
 	}
-	if reflect.DeepEqual(channels[0].Events, []string{"alert"}) != true {
-		t.Errorf("Wrong data for events: %v", channels[0].Events)
+	if reflect.DeepEqual(*(channels[0].Events), []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", *(channels[0].Events))
 	}
-	if reflect.DeepEqual(channels[1].Events, []string{"alert"}) != true {
-		t.Errorf("Wrong data for events: %v", channels[1].Events)
+	if reflect.DeepEqual(*(channels[1].Events), []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", *(channels[1].Events))
 	}
-	if reflect.DeepEqual(channels[2].Events, []string{"alertGroup"}) != true {
-		t.Errorf("Wrong data for events: %v", channels[2].Events)
+	if reflect.DeepEqual(*(channels[2].Events), []string{"alertGroup"}) != true {
+		t.Errorf("Wrong data for events: %v", *(channels[2].Events))
 	}
-	if len(channels[3].Events) > 0 {
-		t.Errorf("Wrong data for events: %v", channels[3].Events)
+	if channels[3].Events != nil {
+		t.Errorf("Wrong data for events: %v", *(channels[3].Events))
 	}
 	if channels[0].URL != "" {
 		t.Error("request has no URL but: ", channels[0])
@@ -225,7 +225,7 @@ func TestCreateChannel(t *testing.T) {
 			Warning: "warning message",
 		},
 		EnabledGraphImage: boolPointer(true),
-		Events:            []string{"alert"},
+		Events:            &[]string{"alert"},
 	})
 
 	if err != nil {
@@ -247,8 +247,8 @@ func TestCreateChannel(t *testing.T) {
 	if !*channel.EnabledGraphImage {
 		t.Error("request sends json including enabledGraphImage but: ", *channel.EnabledGraphImage)
 	}
-	if reflect.DeepEqual(channel.Events, []string{"alert"}) != true {
-		t.Errorf("Wrong data for events: %v", channel.Events)
+	if reflect.DeepEqual(*(channel.Events), []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", *(channel.Events))
 	}
 }
 
@@ -304,7 +304,7 @@ func TestDeleteChannel(t *testing.T) {
 	if !*channel.EnabledGraphImage {
 		t.Error("request sends json including enabledGraphImage but: ", *channel.EnabledGraphImage)
 	}
-	if reflect.DeepEqual(channel.Events, []string{"alert"}) != true {
-		t.Errorf("Wrong data for events: %v", channel.Events)
+	if reflect.DeepEqual(*(channel.Events), []string{"alert"}) != true {
+		t.Errorf("Wrong data for events: %v", *(channel.Events))
 	}
 }

--- a/channels_test.go
+++ b/channels_test.go
@@ -211,7 +211,7 @@ func TestCreateChannel(t *testing.T) {
 
 	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
 
-	channel, err := client.CreateChannel(&ChannelWithoutID{
+	channel, err := client.CreateChannel(&CreateChannelParams{
 		Name: "slack channel",
 		Type: "slack",
 		URL:  "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX",

--- a/channels_test.go
+++ b/channels_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestListChannels(t *testing.T) {
+func TestFindChannels(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/api/v0/channels" {
 			t.Error("request URL should be /api/v0/channels but: ", req.URL.Path)
@@ -62,7 +62,7 @@ func TestListChannels(t *testing.T) {
 	defer ts.Close()
 
 	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
-	channels, err := client.ListChannels()
+	channels, err := client.FindChannels()
 
 	if err != nil {
 		t.Error("err should be nil but: ", err)

--- a/channels_test.go
+++ b/channels_test.go
@@ -75,10 +75,26 @@ func TestListChannels(t *testing.T) {
 		t.Errorf("Wrong data for emails: %v", channels[0].UserIDs)
 	}
 
+	if channels[1].Mentions.OK != "ok message" {
+		t.Error("request has mentions.ok but: ", channels[1].Mentions.OK)
+	}
+	if channels[1].Mentions.Warning != "warning message" {
+		t.Error("request has mentions.warning but: ", channels[1].Mentions.Warning)
+	}
+	if channels[1].Mentions.Critical != "" {
+		t.Error("request does not have mentions.critical but: ", channels[1].Mentions.Critical)
+	}
+
+	if channels[0].URL != "" {
+		t.Error("request has no URL but: ", channels[0])
+	}
 	if channels[1].URL != "https://hooks.slack.com/services/TAAAA/BBBB/XXXXX" {
 		t.Error("request sends json including URL but: ", channels[1])
 	}
 	if channels[2].URL != "http://example.com/webhook" {
 		t.Error("request sends json including URL but: ", channels[2])
+	}
+	if channels[3].URL != "" {
+		t.Error("request has no URL but: ", channels[3])
 	}
 }


### PR DESCRIPTION
I implemented methods that correspond to the APIs listed here: https://mackerel.io/api-docs/entry/channels

- GET `/api/v0/channels`
- POST `/api/v0/channels`
- DELETE `/api/v0/channels/<channelId>`