### PR TITLE
add omitempty tag to types for using to create graph-defs

### DIFF
--- a/graph_defs.go
+++ b/graph_defs.go
@@ -3,15 +3,15 @@ package mackerel
 // GraphDefsParam parameters for posting graph definitions
 type GraphDefsParam struct {
 	Name        string             `json:"name"`
-	DisplayName string             `json:"displayName"`
-	Unit        string             `json:"unit"`
+	DisplayName string             `json:"displayName,omitempty"`
+	Unit        string             `json:"unit,omitempty"`
 	Metrics     []*GraphDefsMetric `json:"metrics"`
 }
 
 // GraphDefsMetric graph metric
 type GraphDefsMetric struct {
 	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName,omitempty"`
 	IsStacked   bool   `json:"isStacked"`
 }
 

--- a/graph_defs_test.go
+++ b/graph_defs_test.go
@@ -83,3 +83,19 @@ func TestCreateGraphDefs(t *testing.T) {
 		t.Error("err should be nil but: ", err)
 	}
 }
+
+func TestGraphDefsOmitJSON(t *testing.T) {
+	g := GraphDefsParam{
+		Metrics: []*GraphDefsMetric{
+			{},
+		},
+	}
+	want := `{"name":"","metrics":[{"name":"","isStacked":false}]}`
+	b, err := json.Marshal(&g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := string(b); s != want {
+		t.Errorf("json.Marshal(%#v) = %q; want %q", g, s, want)
+	}
+}


### PR DESCRIPTION
The API documents describes that these fields are optional.
https://mackerel.io/api-docs/entry/host-metrics#post-graphdef