### PR TITLE
Add Client#ListHosts.

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -301,3 +301,8 @@ func (c *Client) ListHostMetricNames(id string) ([]string, error) {
 	}
 	return data.Names, err
 }
+
+// ListHosts finds hosts
+func (c *Client) ListHosts() ([]*Host, error) {
+	return c.FindHosts(&FindHostsParam{})
+}


### PR DESCRIPTION
If you look at that `Client#FindHosts`,  or API doc, you'll see that you can get a list of hosts if the `FindHostsParam` argument is empty. But it's confusing, so I made a shortcut function for it.