### PR TITLE
closeResponse consumes response body anyway.

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -3,6 +3,8 @@ package mackerel
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -157,6 +159,7 @@ func (c *Client) requestJSON(method string, path string, payload interface{}) (*
 
 func closeResponse(resp *http.Response) {
 	if resp != nil {
+		io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 	}
 }


### PR DESCRIPTION
There are some methods that they close the response body without reading; (e.g `Client#UpdateHostStatus`) In this case, the connection socket can't be reused because of that its transition stops at `TIME_WAIT`. So, I add a reading process to `closeResponse`.