### PR TITLE
drop Type field from Host and introduce Size instead

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -15,7 +15,7 @@ type Host struct {
 	Name             string      `json:"name"`
 	DisplayName      string      `json:"displayName,omitempty"`
 	CustomIdentifier string      `json:"customIdentifier,omitempty"`
-	Type             string      `json:"type"`
+	Size             string      `json:"size"`
 	Status           string      `json:"status"`
 	Memo             string      `json:"memo"`
 	Roles            Roles       `json:"roles"`


### PR DESCRIPTION
On 2021/3/9, we dropped `type` field and added `size` field from response of [`GET /api/v0/hosts/<hostId>`](https://mackerel.io/ja/api-docs/entry/hosts#get). ref: https://github.com/mackerelio/documents/commit/8ef4cd964f9af51f99854557495d88ea5ead52e1
(English documents are not updated yet. We'll soon update them.)

