### PR TITLE
implement aws-integrations APIs

### DIFF
--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -43,18 +43,7 @@ type CreateAWSIntegrationParam struct {
 }
 
 // UpdateAWSIntegrationParam parameters for UpdateAwsIntegration
-type UpdateAWSIntegrationParam struct {
-	Name         string                            `json:"name"`
-	Memo         string                            `json:"memo"`
-	Key          string                            `json:"key,omitempty"`
-	SecretKey    string                            `json:"secretKey,omitempty"`
-	RoleArn      string                            `json:"roleArn,omitempty"`
-	ExternalID   string                            `json:"externalId,omitempty"`
-	Region       string                            `json:"region"`
-	IncludedTags string                            `json:"includedTags"`
-	ExcludedTags string                            `json:"excludedTags"`
-	Services     map[string]*AWSIntegrationService `json:"services"`
-}
+type UpdateAWSIntegrationParam CreateAWSIntegrationParam
 
 // ListAWSIntegrationExcludableMetrics List of excludeable metric names for aws integration
 type ListAWSIntegrationExcludableMetrics map[string][]string

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -61,13 +61,13 @@ func (c *Client) FindAWSIntegrations() ([]*AWSIntegration, error) {
 	}
 
 	var data struct {
-		AwsIntegrations []*AWSIntegration `json:"aws_integrations"`
+		AWSIntegrations []*AWSIntegration `json:"aws_integrations"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	if err != nil {
 		return nil, err
 	}
-	return data.AwsIntegrations, err
+	return data.AWSIntegrations, err
 }
 
 // FindAWSIntegration lists AWS Integration Setting

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -48,8 +48,8 @@ type UpdateAWSIntegrationParam CreateAWSIntegrationParam
 // ListAWSIntegrationExcludableMetrics List of excludeable metric names for aws integration
 type ListAWSIntegrationExcludableMetrics map[string][]string
 
-// ListAWSIntegrations finds AWS Integration Settings
-func (c *Client) ListAWSIntegrations() ([]*AWSIntegration, error) {
+// FindAWSIntegrations finds AWS Integration Settings
+func (c *Client) FindAWSIntegrations() ([]*AWSIntegration, error) {
 	req, err := http.NewRequest("GET", c.urlFor("/api/v0/aws-integrations").String(), nil)
 	if err != nil {
 		return nil, err

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -70,7 +70,7 @@ func (c *Client) FindAWSIntegrations() ([]*AWSIntegration, error) {
 	return data.AWSIntegrations, err
 }
 
-// FindAWSIntegration lists AWS Integration Setting
+// FindAWSIntegration finds AWS Integration Setting
 func (c *Client) FindAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
 	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)).String(), nil)
 	if err != nil {

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -1,0 +1,198 @@
+package mackerel
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// AWSIntegration aws integration information
+type AWSIntegration struct {
+	ID           string                             `json:"id"`
+	Name         string                             `json:"name"`
+	Memo         string                             `json:"memo"`
+	Key          string                             `json:"key,omitempty"`
+	RoleArn      string                             `json:"roleArn,omitempty"`
+	ExternalID   string                             `json:"externalId,omitempty"`
+	Region       string                             `json:"region"`
+	IncludedTags string                             `json:"includedTags"`
+	ExcludedTags string                             `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationServices `json:"services"`
+}
+
+// AWSIntegrationServices integration settings for each AWS service
+type AWSIntegrationServices struct {
+	Enable              bool     `json:"enable"`
+	Role                *string  `json:"role"`
+	ExcludedMetrics     []string `json:"excludedMetrics"`
+	RetireAutomatically bool     `json:"retireAutomatically,omitempty"`
+}
+
+// CreateAWSIntegrationParam  parameters for CreateAWSIntegration
+type CreateAWSIntegrationParam struct {
+	Name         string                             `json:"name"`
+	Memo         string                             `json:"memo"`
+	Key          string                             `json:"key,omitempty"`
+	SecretKey    string                             `json:"secretKey,omitempty"`
+	RoleArn      string                             `json:"roleArn,omitempty"`
+	ExternalID   string                             `json:"externalId,omitempty"`
+	Region       string                             `json:"region"`
+	IncludedTags string                             `json:"includedTags"`
+	ExcludedTags string                             `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationServices `json:"services"`
+}
+
+// UpdateAWSIntegrationParam parameters for UpdateAwsIntegration
+type UpdateAWSIntegrationParam struct {
+	Name         string                             `json:"name"`
+	Memo         string                             `json:"memo"`
+	Key          string                             `json:"key,omitempty"`
+	SecretKey    string                             `json:"secretKey,omitempty"`
+	RoleArn      string                             `json:"roleArn,omitempty"`
+	ExternalID   string                             `json:"externalId,omitempty"`
+	Region       string                             `json:"region"`
+	IncludedTags string                             `json:"includedTags"`
+	ExcludedTags string                             `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationServices `json:"services"`
+}
+
+// ListAWSIntegrationExcludableMetrics List of excludeable metric names for aws integration
+type ListAWSIntegrationExcludableMetrics map[string][]string
+
+// ListAWSIntegrations finds AWS Integration Settings
+func (c *Client) ListAWSIntegrations() ([]*AWSIntegration, error) {
+	req, err := http.NewRequest("GET", c.urlFor("/api/v0/aws-integrations").String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Request(req)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var data struct {
+		AwsIntegrations []*AWSIntegration `json:"aws_integrations"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+	return data.AwsIntegrations, err
+}
+
+// FindAWSIntegration lists AWS Integration Setting
+func (c *Client) FindAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
+	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)).String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Request(req)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var awsIntegration *AWSIntegration
+	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
+	if err != nil {
+		return nil, err
+	}
+	return awsIntegration, err
+}
+
+// CreateAWSIntegration creates AWS Integration Setting
+func (c *Client) CreateAWSIntegration(param *CreateAWSIntegrationParam) (*AWSIntegration, error) {
+	resp, err := c.PostJSON("/api/v0/aws-integrations", param)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var awsIntegration *AWSIntegration
+	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
+	if err != nil {
+		return nil, err
+	}
+	return awsIntegration, err
+}
+
+// UpdateAWSIntegration updates AWS Integration Setting
+func (c *Client) UpdateAWSIntegration(awsIntegrationID string, param *UpdateAWSIntegrationParam) (*AWSIntegration, error) {
+	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID), param)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var awsIntegration *AWSIntegration
+	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
+	if err != nil {
+		return nil, err
+	}
+	return awsIntegration, err
+}
+
+// DeleteAWSIntegration deletes AWS Integration Setting
+func (c *Client) DeleteAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
+	req, err := http.NewRequest(
+		"DELETE",
+		c.urlFor(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)).String(),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := c.Request(req)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var awsIntegration *AWSIntegration
+	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
+	if err != nil {
+		return nil, err
+	}
+	return awsIntegration, err
+}
+
+// CreateAWSIntegrationExternalID creates AWS Integration External ID
+func (c *Client) CreateAWSIntegrationExternalID() (string, error) {
+	resp, err := c.PostJSON("/api/v0/aws-integrations-external-id", nil)
+	defer closeResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	var data struct {
+		ExternalID string `json:"externalId"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return "", err
+	}
+	return data.ExternalID, nil
+}
+
+// ListAWSIntegrationExcludableMetrics lists excludable metrics for AWS Integration
+func (c *Client) ListAWSIntegrationExcludableMetrics() (*ListAWSIntegrationExcludableMetrics, error) {
+	req, err := http.NewRequest("GET", c.urlFor("/api/v0/aws-integrations-excludable-metrics").String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Request(req)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var listAWSIntegrationExcludableMetrics *ListAWSIntegrationExcludableMetrics
+	err = json.NewDecoder(resp.Body).Decode(&listAWSIntegrationExcludableMetrics)
+	if err != nil {
+		return nil, err
+	}
+	return listAWSIntegrationExcludableMetrics, err
+}

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -8,20 +8,20 @@ import (
 
 // AWSIntegration aws integration information
 type AWSIntegration struct {
-	ID           string                             `json:"id"`
-	Name         string                             `json:"name"`
-	Memo         string                             `json:"memo"`
-	Key          string                             `json:"key,omitempty"`
-	RoleArn      string                             `json:"roleArn,omitempty"`
-	ExternalID   string                             `json:"externalId,omitempty"`
-	Region       string                             `json:"region"`
-	IncludedTags string                             `json:"includedTags"`
-	ExcludedTags string                             `json:"excludedTags"`
-	Services     map[string]*AWSIntegrationServices `json:"services"`
+	ID           string                            `json:"id"`
+	Name         string                            `json:"name"`
+	Memo         string                            `json:"memo"`
+	Key          string                            `json:"key,omitempty"`
+	RoleArn      string                            `json:"roleArn,omitempty"`
+	ExternalID   string                            `json:"externalId,omitempty"`
+	Region       string                            `json:"region"`
+	IncludedTags string                            `json:"includedTags"`
+	ExcludedTags string                            `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationService `json:"services"`
 }
 
-// AWSIntegrationServices integration settings for each AWS service
-type AWSIntegrationServices struct {
+// AWSIntegrationService integration settings for each AWS service
+type AWSIntegrationService struct {
 	Enable              bool     `json:"enable"`
 	Role                *string  `json:"role"`
 	ExcludedMetrics     []string `json:"excludedMetrics"`
@@ -30,30 +30,30 @@ type AWSIntegrationServices struct {
 
 // CreateAWSIntegrationParam  parameters for CreateAWSIntegration
 type CreateAWSIntegrationParam struct {
-	Name         string                             `json:"name"`
-	Memo         string                             `json:"memo"`
-	Key          string                             `json:"key,omitempty"`
-	SecretKey    string                             `json:"secretKey,omitempty"`
-	RoleArn      string                             `json:"roleArn,omitempty"`
-	ExternalID   string                             `json:"externalId,omitempty"`
-	Region       string                             `json:"region"`
-	IncludedTags string                             `json:"includedTags"`
-	ExcludedTags string                             `json:"excludedTags"`
-	Services     map[string]*AWSIntegrationServices `json:"services"`
+	Name         string                            `json:"name"`
+	Memo         string                            `json:"memo"`
+	Key          string                            `json:"key,omitempty"`
+	SecretKey    string                            `json:"secretKey,omitempty"`
+	RoleArn      string                            `json:"roleArn,omitempty"`
+	ExternalID   string                            `json:"externalId,omitempty"`
+	Region       string                            `json:"region"`
+	IncludedTags string                            `json:"includedTags"`
+	ExcludedTags string                            `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationService `json:"services"`
 }
 
 // UpdateAWSIntegrationParam parameters for UpdateAwsIntegration
 type UpdateAWSIntegrationParam struct {
-	Name         string                             `json:"name"`
-	Memo         string                             `json:"memo"`
-	Key          string                             `json:"key,omitempty"`
-	SecretKey    string                             `json:"secretKey,omitempty"`
-	RoleArn      string                             `json:"roleArn,omitempty"`
-	ExternalID   string                             `json:"externalId,omitempty"`
-	Region       string                             `json:"region"`
-	IncludedTags string                             `json:"includedTags"`
-	ExcludedTags string                             `json:"excludedTags"`
-	Services     map[string]*AWSIntegrationServices `json:"services"`
+	Name         string                            `json:"name"`
+	Memo         string                            `json:"memo"`
+	Key          string                            `json:"key,omitempty"`
+	SecretKey    string                            `json:"secretKey,omitempty"`
+	RoleArn      string                            `json:"roleArn,omitempty"`
+	ExternalID   string                            `json:"externalId,omitempty"`
+	Region       string                            `json:"region"`
+	IncludedTags string                            `json:"includedTags"`
+	ExcludedTags string                            `json:"excludedTags"`
+	Services     map[string]*AWSIntegrationService `json:"services"`
 }
 
 // ListAWSIntegrationExcludableMetrics List of excludeable metric names for aws integration

--- a/aws_integrations_test.go
+++ b/aws_integrations_test.go
@@ -89,7 +89,7 @@ func TestFindAWSIntegrations(t *testing.T) {
 	defer ts.Close()
 
 	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
-	awsIntegrations, err := client.ListAWSIntegrations()
+	awsIntegrations, err := client.FindAWSIntegrations()
 	if err != nil {
 		t.Error("err should be nil but: ", err)
 	}

--- a/aws_integrations_test.go
+++ b/aws_integrations_test.go
@@ -98,7 +98,7 @@ func TestFindAWSIntegrations(t *testing.T) {
 		t.Error("aws integrations id should be empty but: ", awsIntegrations[0].ID)
 	}
 
-	if reflect.DeepEqual(awsIntegrations[0].Services["EC2"], &AWSIntegrationServices{
+	if reflect.DeepEqual(awsIntegrations[0].Services["EC2"], &AWSIntegrationService{
 		Enable:              true,
 		Role:                toPointer("web-group"),
 		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -164,7 +164,7 @@ func TestFindAWSIntegration(t *testing.T) {
 		t.Error("aws integrations id should be empty but: ", awsIntegration.ID)
 	}
 
-	if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+	if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationService{
 		Enable:              true,
 		Role:                toPointer("web-group"),
 		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -196,7 +196,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 			t.Error("request sends json including name but: ", awsIntegration.Name)
 		}
 
-		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationService{
 			Enable:              true,
 			Role:                toPointer("web-group"),
 			ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -252,7 +252,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 		Region:       "ap-northeast-1",
 		IncludedTags: "Name:web-server,Environment:staging,Product:web",
 		ExcludedTags: "Name:test-server,Environment:staging,Product:test",
-		Services: map[string]*AWSIntegrationServices{
+		Services: map[string]*AWSIntegrationService{
 			"EC2": {
 				Enable:              true,
 				Role:                toPointer("web-group"),
@@ -280,7 +280,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 		t.Error("aws integrations id should be empty but ", awsIntegrations.ID)
 	}
 
-	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationService{
 		Enable:              true,
 		Role:                toPointer("web-group"),
 		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -312,7 +312,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 			t.Error("request sends json including name but: ", awsIntegration.Name)
 		}
 
-		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationService{
 			Enable:              true,
 			Role:                toPointer("web-group"),
 			ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -368,7 +368,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 		Region:       "ap-northeast-1",
 		IncludedTags: "Name:web-server,Environment:staging,Product:web",
 		ExcludedTags: "Name:test-server,Environment:staging,Product:test",
-		Services: map[string]*AWSIntegrationServices{
+		Services: map[string]*AWSIntegrationService{
 			"EC2": {
 				Enable:              true,
 				Role:                toPointer("web-group"),
@@ -396,7 +396,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 		t.Error("aws integrations id should be empty but: ", awsIntegrations.ID)
 	}
 
-	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationService{
 		Enable:              true,
 		Role:                toPointer("web-group"),
 		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
@@ -461,7 +461,7 @@ func TestDeleteAWSIntegration(t *testing.T) {
 		t.Error("aws integrations id should be empty but: ", awsIntegrations.ID)
 	}
 
-	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationService{
 		Enable:              true,
 		Role:                toPointer("web-group"),
 		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},

--- a/aws_integrations_test.go
+++ b/aws_integrations_test.go
@@ -1,0 +1,549 @@
+package mackerel
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestFindAWSIntegrations(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/aws-integrations" {
+			t.Error("request URL should be /api/v0/aws-integrations but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string][]map[string]interface{}{
+			"aws_integrations": {
+				{
+					"id":           "9rxGOHfVF8F",
+					"name":         "my-aws-integrations-1",
+					"memo":         "my-aws-integrations-1",
+					"key":          "ADIUHIBCGY6VXDMAUAA5E",
+					"roleArn":      "",
+					"externalId":   "",
+					"region":       "ap-northeast-1",
+					"includedTags": "Name:web-server,Environment:staging,Product:web",
+					"excludedTags": "Name:test-server,Environment:staging,Product:test",
+					"Services": map[string]map[string]interface{}{
+						"EC2": {
+							"enable":              true,
+							"role":                "web-group",
+							"excludedMetrics":     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+							"retireAutomatically": true,
+						},
+						"ALB": {
+							"enable":          true,
+							"role":            "web-group",
+							"excludedMetrics": []string{"alb.request.count"},
+						},
+						"RDS": {
+							"enable":          true,
+							"role":            "db-group",
+							"excludedMetrics": []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+						},
+					},
+				},
+				{
+					"id":           "9rxGOHfb12F",
+					"name":         "my-aws-integrations-2",
+					"memo":         "",
+					"key":          "",
+					"roleArn":      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+					"externalId":   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+					"region":       "eu-central-1",
+					"includedTags": "Name:web-server,Environment:staging,Product:web",
+					"excludedTags": "Name:test-server,Environment:staging,Product:test",
+					"Services": map[string]map[string]interface{}{
+						"EC2": {
+							"enable":              false,
+							"role":                (*string)(nil),
+							"excludedMetrics":     []string{""},
+							"retireAutomatically": false,
+						},
+						"ALB": {
+							"enable":          false,
+							"role":            (*string)(nil),
+							"excludedMetrics": []string{""},
+						},
+						"RDS": {
+							"enable":          false,
+							"role":            (*string)(nil),
+							"excludedMetrics": []string{""},
+						},
+					},
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegrations, err := client.ListAWSIntegrations()
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegrations[0].ID != "9rxGOHfVF8F" {
+		t.Error("aws integrations id should be empty but: ", awsIntegrations[0].ID)
+	}
+
+	if reflect.DeepEqual(awsIntegrations[0].Services["EC2"], &AWSIntegrationServices{
+		Enable:              true,
+		Role:                toPointer("web-group"),
+		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+		RetireAutomatically: true,
+	}) != true {
+		t.Errorf("Wrong data for aws integrations services: %v", awsIntegrations[0].Services["EC2"])
+	}
+}
+
+func TestFindAWSIntegration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		url := fmt.Sprintf("/api/v0/aws-integrations/%s", "9rxGOHfVF8F")
+		if req.URL.Path != url {
+			t.Error("request URL should be /api/v0/aws-integrations/<ID> but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"id":           "9rxGOHfVF8F",
+			"name":         "my-aws-integrations-1",
+			"memo":         "my-aws-integrations-1",
+			"key":          "ADIUHIBCGY6VXDMAUAA5E",
+			"roleArn":      "",
+			"externalId":   "",
+			"region":       "ap-northeast-1",
+			"includedTags": "Name:web-server,Environment:staging,Product:web",
+			"excludedTags": "Name:test-server,Environment:staging,Product:test",
+			"Services": map[string]map[string]interface{}{
+				"EC2": {
+					"enable":              true,
+					"role":                "web-group",
+					"excludedMetrics":     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+					"retireAutomatically": true,
+				},
+				"ALB": {
+					"enable":          true,
+					"role":            "web-group",
+					"excludedMetrics": []string{"alb.request.count"},
+				},
+				"RDS": {
+					"enable":          true,
+					"role":            "db-group",
+					"excludedMetrics": []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegration, err := client.FindAWSIntegration("9rxGOHfVF8F")
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegration.ID != "9rxGOHfVF8F" {
+		t.Error("aws integrations id should be empty but: ", awsIntegration.ID)
+	}
+
+	if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+		Enable:              true,
+		Role:                toPointer("web-group"),
+		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+		RetireAutomatically: true,
+	}) != true {
+		t.Errorf("Wrong data for aws integration services: %v", awsIntegration.Services["EC2"])
+	}
+}
+
+func TestCreateAWSIntegration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/aws-integrations" {
+			t.Error("request URL should be /api/v0/aws-integrations but: ", req.URL.Path)
+		}
+
+		if req.Method != "POST" {
+			t.Error("request method should be POST but: ", req.Method)
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+
+		var awsIntegration *AWSIntegration
+		err := json.Unmarshal(body, &awsIntegration)
+		if err != nil {
+			t.Fatal("request body should be decoded as json", string(body))
+		}
+
+		if awsIntegration.Name != "my-aws-integrations-1" {
+			t.Error("request sends json including name but: ", awsIntegration.Name)
+		}
+
+		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+			Enable:              true,
+			Role:                toPointer("web-group"),
+			ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+			RetireAutomatically: true,
+		}) != true {
+			t.Errorf("Wrong data for aws integration services: %v", awsIntegration.Services["EC2"])
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"id":           "9rxGOHfVF8F",
+			"name":         "my-aws-integrations-1",
+			"memo":         "my-aws-integrations-1",
+			"key":          "",
+			"secretKey":    "",
+			"roleArn":      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+			"externalId":   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+			"region":       "ap-northeast-1",
+			"includedTags": "Name:web-server,Environment:staging,Product:web",
+			"excludedTags": "Name:test-server,Environment:staging,Product:test",
+			"Services": map[string]map[string]interface{}{
+				"EC2": {
+					"enable":              true,
+					"role":                "web-group",
+					"excludedMetrics":     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+					"retireAutomatically": true,
+				},
+				"ALB": {
+					"enable":          true,
+					"role":            "web-group",
+					"excludedMetrics": []string{"alb.request.count"},
+				},
+				"RDS": {
+					"enable":          true,
+					"role":            "db-group",
+					"excludedMetrics": []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegrations, err := client.CreateAWSIntegration(&CreateAWSIntegrationParam{
+		Name:         "my-aws-integrations-1",
+		Memo:         "my-aws-integrations-1",
+		Key:          "",
+		SecretKey:    "",
+		RoleArn:      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+		ExternalID:   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+		Region:       "ap-northeast-1",
+		IncludedTags: "Name:web-server,Environment:staging,Product:web",
+		ExcludedTags: "Name:test-server,Environment:staging,Product:test",
+		Services: map[string]*AWSIntegrationServices{
+			"EC2": {
+				Enable:              true,
+				Role:                toPointer("web-group"),
+				ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+				RetireAutomatically: true,
+			},
+			"ALB": {
+				Enable:          true,
+				Role:            toPointer("web-group"),
+				ExcludedMetrics: []string{"alb.request.count"},
+			},
+			"RDS": {
+				Enable:          true,
+				Role:            toPointer("db-group"),
+				ExcludedMetrics: []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegrations.ID != "9rxGOHfVF8F" {
+		t.Error("aws integrations id should be empty but ", awsIntegrations.ID)
+	}
+
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+		Enable:              true,
+		Role:                toPointer("web-group"),
+		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+		RetireAutomatically: true,
+	}) != true {
+		t.Errorf("Wrong data for aws integration services: %v", awsIntegrations.Services["EC2"])
+	}
+}
+
+func TestUpdateAWSIntegration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != fmt.Sprintf("/api/v0/aws-integrations/%s", "9rxGOHfVF8F") {
+			t.Error("request URL should be /api/v0/aws-integrations/<ID> but: ", req.URL.Path)
+		}
+
+		if req.Method != "PUT" {
+			t.Error("request method should be PUT but: ", req.Method)
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+
+		var awsIntegration *AWSIntegration
+		err := json.Unmarshal(body, &awsIntegration)
+		if err != nil {
+			t.Fatal("request body should be decoded as json", string(body))
+		}
+
+		if awsIntegration.Name != "my-aws-integrations-1" {
+			t.Error("request sends json including name but: ", awsIntegration.Name)
+		}
+
+		if reflect.DeepEqual(awsIntegration.Services["EC2"], &AWSIntegrationServices{
+			Enable:              true,
+			Role:                toPointer("web-group"),
+			ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+			RetireAutomatically: true,
+		}) != true {
+			t.Errorf("Wrong data for aws integration services: %v", awsIntegration.Services["EC2"])
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"id":           "9rxGOHfVF8F",
+			"name":         "my-aws-integrations-1",
+			"memo":         "my-aws-integrations-1",
+			"key":          "",
+			"secretKey":    "",
+			"roleArn":      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+			"externalId":   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+			"region":       "ap-northeast-1",
+			"includedTags": "Name:web-server,Environment:staging,Product:web",
+			"excludedTags": "Name:test-server,Environment:staging,Product:test",
+			"Services": map[string]map[string]interface{}{
+				"EC2": {
+					"enable":              true,
+					"role":                "web-group",
+					"excludedMetrics":     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+					"retireAutomatically": true,
+				},
+				"ALB": {
+					"enable":          true,
+					"role":            "web-group",
+					"excludedMetrics": []string{"alb.request.count"},
+				},
+				"RDS": {
+					"enable":          true,
+					"role":            "db-group",
+					"excludedMetrics": []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegrations, err := client.UpdateAWSIntegration("9rxGOHfVF8F", &UpdateAWSIntegrationParam{
+		Name:         "my-aws-integrations-1",
+		Memo:         "my-aws-integrations-1",
+		Key:          "",
+		SecretKey:    "",
+		RoleArn:      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+		ExternalID:   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+		Region:       "ap-northeast-1",
+		IncludedTags: "Name:web-server,Environment:staging,Product:web",
+		ExcludedTags: "Name:test-server,Environment:staging,Product:test",
+		Services: map[string]*AWSIntegrationServices{
+			"EC2": {
+				Enable:              true,
+				Role:                toPointer("web-group"),
+				ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+				RetireAutomatically: true,
+			},
+			"ALB": {
+				Enable:          true,
+				Role:            toPointer("web-group"),
+				ExcludedMetrics: []string{"alb.request.count"},
+			},
+			"RDS": {
+				Enable:          true,
+				Role:            toPointer("db-group"),
+				ExcludedMetrics: []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegrations.ID != "9rxGOHfVF8F" {
+		t.Error("aws integrations id should be empty but: ", awsIntegrations.ID)
+	}
+
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+		Enable:              true,
+		Role:                toPointer("web-group"),
+		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+		RetireAutomatically: true,
+	}) != true {
+		t.Errorf("Wrong data for aws integration services: %v", awsIntegrations.Services["EC2"])
+	}
+}
+
+func TestDeleteAWSIntegration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != fmt.Sprintf("/api/v0/aws-integrations/%s", "9rxGOHfVF8F") {
+			t.Error("request URL should be /api/v0/aws-integrations/<ID> but: ", req.URL.Path)
+		}
+
+		if req.Method != "DELETE" {
+			t.Error("request method should be DELETE but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"id":           "9rxGOHfVF8F",
+			"name":         "my-aws-integrations-1",
+			"memo":         "my-aws-integrations-1",
+			"key":          "",
+			"roleArn":      "arn:aws:iam::111111111111:role/MackerelIntegrationRole",
+			"externalId":   "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+			"region":       "ap-northeast-1",
+			"includedTags": "Name:web-server,Environment:staging,Product:web",
+			"excludedTags": "Name:test-server,Environment:staging,Product:test",
+			"Services": map[string]map[string]interface{}{
+				"EC2": {
+					"enable":              true,
+					"role":                "web-group",
+					"excludedMetrics":     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+					"retireAutomatically": true,
+				},
+				"ALB": {
+					"enable":          true,
+					"role":            "web-group",
+					"excludedMetrics": []string{"alb.request.count"},
+				},
+				"RDS": {
+					"enable":          true,
+					"role":            "db-group",
+					"excludedMetrics": []string{"rds.cpu.used", "rds.aurora.row_lock_time.row_lock"},
+				},
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegrations, err := client.DeleteAWSIntegration("9rxGOHfVF8F")
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegrations.ID != "9rxGOHfVF8F" {
+		t.Error("aws integrations id should be empty but: ", awsIntegrations.ID)
+	}
+
+	if reflect.DeepEqual(awsIntegrations.Services["EC2"], &AWSIntegrationServices{
+		Enable:              true,
+		Role:                toPointer("web-group"),
+		ExcludedMetrics:     []string{"ec2.cpu.used", "ec2.network.in", "ec2.network.out"},
+		RetireAutomatically: true,
+	}) != true {
+		t.Errorf("Wrong data for aws integration services: %v", awsIntegrations.Services["EC2"])
+	}
+}
+
+func TestCreateAWSIntegrationExternalID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/aws-integrations-external-id" {
+			t.Error("request URL should be /api/v0/aws-integrations-external-id but: ", req.URL.Path)
+		}
+
+		if req.Method != "POST" {
+			t.Error("request method should be POST but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string]string{
+			"externalId": "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2",
+		})
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	awsIntegrationExternalID, err := client.CreateAWSIntegrationExternalID()
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if awsIntegrationExternalID != "PyrtkY42H8poFvRBU42dNL12BIPd9dF9QaCe1pgoXK2" {
+		t.Error("aws integration external id should be empty but: ", awsIntegrationExternalID)
+	}
+}
+
+func TestListAWSIntegrationExcludableMetrics(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/aws-integrations-excludable-metrics" {
+			t.Error("request URL should be /api/v0/aws-integrations-excludable-metrics but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		respJSON, _ := json.Marshal(map[string][]string{
+			"EC2": {
+				"ec2.cpu.used",
+				"ec2.cpu_credit.used",
+				"ec2.cpu_credit.balance",
+			},
+			"ELB": {
+				"elb.count.request_count",
+				"elb.host_count.healthy",
+				"elb.host_count.unhealthy",
+			},
+			"ALB": {
+				"alb.request.count",
+				"alb.bytes.processed",
+				"alb.httpcode_count.target_2xx",
+			},
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON))
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+	listAWSIntegrationExcludableMetrics, err := client.ListAWSIntegrationExcludableMetrics()
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if reflect.DeepEqual((*listAWSIntegrationExcludableMetrics)["EC2"], []string{"ec2.cpu.used", "ec2.cpu_credit.used", "ec2.cpu_credit.balance"}) != true {
+		t.Errorf("Wrong data for list of excludeable metric names for aws integration: %v", (*listAWSIntegrationExcludableMetrics)["EC2"])
+	}
+}
+
+func toPointer(s string) *string {
+	return &s
+}

--- a/aws_integrations_test.go
+++ b/aws_integrations_test.go
@@ -32,7 +32,7 @@ func TestFindAWSIntegrations(t *testing.T) {
 					"region":       "ap-northeast-1",
 					"includedTags": "Name:web-server,Environment:staging,Product:web",
 					"excludedTags": "Name:test-server,Environment:staging,Product:test",
-					"Services": map[string]map[string]interface{}{
+					"services": map[string]map[string]interface{}{
 						"EC2": {
 							"enable":              true,
 							"role":                "web-group",
@@ -61,7 +61,7 @@ func TestFindAWSIntegrations(t *testing.T) {
 					"region":       "eu-central-1",
 					"includedTags": "Name:web-server,Environment:staging,Product:web",
 					"excludedTags": "Name:test-server,Environment:staging,Product:test",
-					"Services": map[string]map[string]interface{}{
+					"services": map[string]map[string]interface{}{
 						"EC2": {
 							"enable":              false,
 							"role":                (*string)(nil),
@@ -129,7 +129,7 @@ func TestFindAWSIntegration(t *testing.T) {
 			"region":       "ap-northeast-1",
 			"includedTags": "Name:web-server,Environment:staging,Product:web",
 			"excludedTags": "Name:test-server,Environment:staging,Product:test",
-			"Services": map[string]map[string]interface{}{
+			"services": map[string]map[string]interface{}{
 				"EC2": {
 					"enable":              true,
 					"role":                "web-group",
@@ -216,7 +216,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 			"region":       "ap-northeast-1",
 			"includedTags": "Name:web-server,Environment:staging,Product:web",
 			"excludedTags": "Name:test-server,Environment:staging,Product:test",
-			"Services": map[string]map[string]interface{}{
+			"services": map[string]map[string]interface{}{
 				"EC2": {
 					"enable":              true,
 					"role":                "web-group",
@@ -332,7 +332,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 			"region":       "ap-northeast-1",
 			"includedTags": "Name:web-server,Environment:staging,Product:web",
 			"excludedTags": "Name:test-server,Environment:staging,Product:test",
-			"Services": map[string]map[string]interface{}{
+			"services": map[string]map[string]interface{}{
 				"EC2": {
 					"enable":              true,
 					"role":                "web-group",
@@ -426,7 +426,7 @@ func TestDeleteAWSIntegration(t *testing.T) {
 			"region":       "ap-northeast-1",
 			"includedTags": "Name:web-server,Environment:staging,Product:web",
 			"excludedTags": "Name:test-server,Environment:staging,Product:test",
-			"Services": map[string]map[string]interface{}{
+			"services": map[string]map[string]interface{}{
 				"EC2": {
 					"enable":              true,
 					"role":                "web-group",


### PR DESCRIPTION
Hello:wave:
aws-integrations APIs did not appear to be implemented, so I implemented it.
I would like to use terraform-provider-mackerel to manage my AWS integration settings, and I think this pull request needs to be merged for that purpose.
I will write a separate PR for the terraform-provider-mackerel implementation as soon as this PR is merged.
ref: https://mackerel.io/api-docs/entry/aws-integration