### PR TITLE
Add followRedirect in external http monitors

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -70,6 +70,7 @@ import (
       "requestBody": "Request Body",
       "containsString": "Example",
       "skipCertificateVerification": true,
+      "followRedirect": true,
       "headers": [
         { "name": "Cache-Control", "value": "no-cache"}
       ]
@@ -230,6 +231,7 @@ type MonitorExternalHTTP struct {
 	CertificationExpirationCritical *uint64  `json:"certificationExpirationCritical,omitempty"`
 	CertificationExpirationWarning  *uint64  `json:"certificationExpirationWarning,omitempty"`
 	SkipCertificateVerification     bool     `json:"skipCertificateVerification,omitempty"`
+	FollowRedirect                  bool     `json:"followRedirect,omitempty"`
 	// Empty list of headers and nil are different. You have to specify empty
 	// list as headers explicitly if you want to remove all headers instead of
 	// using nil.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -52,6 +52,7 @@ func TestFindMonitors(t *testing.T) {
 					"certificationExpirationWarning":  30,
 					"containsString":                  "Foo Bar Baz",
 					"skipCertificateVerification":     true,
+					"followRedirect":                  true,
 					"headers": []map[string]interface{}{
 						{"name": "Cache-Control", "value": "no-cache"},
 					},
@@ -150,6 +151,10 @@ func TestFindMonitors(t *testing.T) {
 
 		if m.SkipCertificateVerification != true {
 			t.Error("request sends json including skipCertificateVerification but: ", m)
+		}
+
+		if m.FollowRedirect != true {
+			t.Error("request sends json including followRedirect but: ", m)
 		}
 
 		if !reflect.DeepEqual(m.Headers, []HeaderField{{Name: "Cache-Control", Value: "no-cache"}}) {


### PR DESCRIPTION
Add feature for "Redirects can now be followed in external monitoring" indicated by https://mackerel.io/blog/entry/weekly/20201102 