### PR TITLE
add Memo field to mackerel.Host

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -84,6 +84,7 @@ type FindHostsParam struct {
 type CreateHostParam struct {
 	Name             string        `json:"name"`
 	DisplayName      string        `json:"displayName,omitempty"`
+	Memo             string        `json:"memo,omitempty"`
 	Meta             HostMeta      `json:"meta"`
 	Interfaces       []Interface   `json:"interfaces"`
 	RoleFullnames    []string      `json:"roleFullnames"`


### PR DESCRIPTION
The hosts API now accepts new memo registrations.
reference https://github.com/mackerelio/documents/commit/a26b879dd200bae2bc2eb5af147bbc39b98052b7