### PR TITLE
refactor: unify error data struct

### DIFF
--- a/error.go
+++ b/error.go
@@ -24,9 +24,8 @@ func extractErrorMessage(r io.Reader) (errorMessage string, err error) {
 	}
 	var data struct{ Error struct{ Message string } }
 	err = json.Unmarshal(bs, &data)
-	if err == nil {
-		return data.Error.Message, nil
-	} else {
+	if err != nil {
 		return "", err
 	}
+	return data.Error.Message, nil
 }

--- a/error.go
+++ b/error.go
@@ -17,19 +17,16 @@ func (err *APIError) Error() string {
 	return fmt.Sprintf("API request failed: %s", err.Message)
 }
 
-func extractErrorMessage(r io.Reader) (errorMessage string) {
+func extractErrorMessage(r io.Reader) (errorMessage string, err error) {
 	bs, err := ioutil.ReadAll(r)
 	if err != nil {
-		return
+		return "", err
 	}
 	var data struct{ Error struct{ Message string } }
 	err = json.Unmarshal(bs, &data)
 	if err == nil {
-		errorMessage = data.Error.Message
+		return data.Error.Message, nil
 	} else {
-		var data struct{ Error string }
-		json.Unmarshal(bs, &data)
-		errorMessage = data.Error
+		return "", err
 	}
-	return
 }

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -456,8 +456,8 @@ func TestRetireHost_NotFound(t *testing.T) {
 			t.Error("request method should be POST but: ", req.Method)
 		}
 
-		respJSON, _ := json.Marshal(map[string]string{
-			"error": "Host Not Found.",
+		respJSON, _ := json.Marshal(map[string]map[string]string{
+			"error": {"message": "Host Not Found."},
 		})
 
 		res.Header()["Content-Type"] = []string{"application/json"}
@@ -544,8 +544,8 @@ func TestBulkRetireHosts_NotFound(t *testing.T) {
 			t.Errorf("request IDs should be %+v but: %+v", expectIDs, data.IDs)
 		}
 
-		respJSON, _ := json.Marshal(map[string]string{
-			"error": "Hosts not found.",
+		respJSON, _ := json.Marshal(map[string]map[string]string{
+			"error": {"message": "Hosts Not Found."},
 		})
 
 		res.Header()["Content-Type"] = []string{"application/json"}
@@ -569,7 +569,7 @@ func TestBulkRetireHosts_NotFound(t *testing.T) {
 	if expectStatus := http.StatusNotFound; apiErr.StatusCode != expectStatus {
 		t.Errorf("api error StatusCode should be %d but got %d", expectStatus, apiErr.StatusCode)
 	}
-	if expect := "API request failed: Hosts not found."; apiErr.Error() != expect {
+	if expect := "API request failed: Hosts Not Found."; apiErr.Error() != expect {
 		t.Errorf("api error string should be \"%s\" but got \"%s\"", expect, apiErr.Error())
 	}
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -122,12 +122,12 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 		}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		message := extractErrorMessage(resp.Body)
+		message, err := extractErrorMessage(resp.Body)
 		defer resp.Body.Close()
-		if message != "" {
-			return nil, &APIError{StatusCode: resp.StatusCode, Message: message}
+		if err != nil {
+			return nil, &APIError{StatusCode: resp.StatusCode, Message: resp.Status}
 		}
-		return nil, &APIError{StatusCode: resp.StatusCode, Message: resp.Status}
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: message}
 	}
 	return resp, nil
 }


### PR DESCRIPTION
error response is always `struct{ Error struct{ Message string } }`
ref: https://mackerel.io/ja/blog/entry/weekly/20221101