### PR TITLE
Reduce code for building requests and decoding response bodies

### DIFF
--- a/alert_group_settings.go
+++ b/alert_group_settings.go
@@ -1,10 +1,6 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
 // AlertGroupSetting represents a Mackerel alert group setting.
 // ref. https://mackerel.io/api-docs/entry/alert-group-settings
@@ -18,102 +14,36 @@ type AlertGroupSetting struct {
 	NotificationInterval uint64   `json:"notificationInterval,omitempty"`
 }
 
-// FindAlertGroupSettings finds alert group settings
+// FindAlertGroupSettings finds alert group settings.
 func (c *Client) FindAlertGroupSettings() ([]*AlertGroupSetting, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/alert-group-settings").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		AlertGroupSettings []*AlertGroupSetting `json:"alertGroupSettings"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+	}](c, "/api/v0/alert-group-settings")
+	if err != nil {
 		return nil, err
 	}
-
 	return data.AlertGroupSettings, nil
 }
 
-// CreateAlertGroupSetting creates a alert group setting
+// CreateAlertGroupSetting creates an alert group setting.
 func (c *Client) CreateAlertGroupSetting(param *AlertGroupSetting) (*AlertGroupSetting, error) {
-	resp, err := c.PostJSON("/api/v0/alert-group-settings", param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var alertGroupSetting AlertGroupSetting
-	if err := json.NewDecoder(resp.Body).Decode(&alertGroupSetting); err != nil {
-		return nil, err
-	}
-
-	return &alertGroupSetting, nil
+	return requestPost[AlertGroupSetting](c, "/api/v0/alert-group-settings", param)
 }
 
-// GetAlertGroupSetting gets alert group setting specified by ID
+// GetAlertGroupSetting gets an alert group setting.
 func (c *Client) GetAlertGroupSetting(id string) (*AlertGroupSetting, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/alert-group-settings/%s", id)).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var alertGroupSetting AlertGroupSetting
-	if err := json.NewDecoder(resp.Body).Decode(&alertGroupSetting); err != nil {
-		return nil, err
-	}
-
-	return &alertGroupSetting, nil
+	path := fmt.Sprintf("/api/v0/alert-group-settings/%s", id)
+	return requestGet[AlertGroupSetting](c, path)
 }
 
-// UpdateAlertGroupSetting updates a alert group setting
+// UpdateAlertGroupSetting updates an alert group setting.
 func (c *Client) UpdateAlertGroupSetting(id string, param *AlertGroupSetting) (*AlertGroupSetting, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/alert-group-settings/%s", id), param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var alertGroupSetting AlertGroupSetting
-	if err := json.NewDecoder(resp.Body).Decode(&alertGroupSetting); err != nil {
-		return nil, err
-	}
-
-	return &alertGroupSetting, nil
+	path := fmt.Sprintf("/api/v0/alert-group-settings/%s", id)
+	return requestPut[AlertGroupSetting](c, path, param)
 }
 
-// DeleteAlertGroupSetting deletes a alert group setting specified by ID.
+// DeleteAlertGroupSetting deletes an alert group setting.
 func (c *Client) DeleteAlertGroupSetting(id string) (*AlertGroupSetting, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/alert-group-settings/%s", id)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var alertGroupSetting AlertGroupSetting
-	if err := json.NewDecoder(resp.Body).Decode(&alertGroupSetting); err != nil {
-		return nil, err
-	}
-
-	return &alertGroupSetting, nil
+	path := fmt.Sprintf("/api/v0/alert-group-settings/%s", id)
+	return requestDelete[AlertGroupSetting](c, path)
 }

--- a/alerts.go
+++ b/alerts.go
@@ -1,9 +1,7 @@
 package mackerel
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 )
 
@@ -61,108 +59,51 @@ type UpdateAlertResponse struct {
 	Memo string `json:"memo,omitempty"`
 }
 
-func (c *Client) findAlertsWithParam(v url.Values) (*AlertsResp, error) {
-	var d AlertsResp
-	u := c.urlFor("/api/v0/alerts")
-	u.RawQuery = v.Encode()
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(&d)
-	if err != nil {
-		return nil, err
-	}
-	return &d, err
+func (c *Client) findAlertsWithParams(params url.Values) (*AlertsResp, error) {
+	return requestGetWithParams[AlertsResp](c, "/api/v0/alerts", params)
 }
 
-// FindAlerts find open alerts
+// FindAlerts finds open alerts.
 func (c *Client) FindAlerts() (*AlertsResp, error) {
-	return c.findAlertsWithParam(url.Values{})
+	return c.findAlertsWithParams(nil)
 }
 
-// FindAlertsByNextID find next open alerts by next id
+// FindAlertsByNextID finds next open alerts by next id.
 func (c *Client) FindAlertsByNextID(nextID string) (*AlertsResp, error) {
-	v := url.Values{}
-	v.Set("nextId", nextID)
-	return c.findAlertsWithParam(v)
+	params := url.Values{}
+	params.Set("nextId", nextID)
+	return c.findAlertsWithParams(params)
 }
 
-// FindWithClosedAlerts find open and close alerts
+// FindWithClosedAlerts finds open and close alerts.
 func (c *Client) FindWithClosedAlerts() (*AlertsResp, error) {
-	v := url.Values{}
-	v.Set("withClosed", "true")
-	return c.findAlertsWithParam(v)
+	params := url.Values{}
+	params.Set("withClosed", "true")
+	return c.findAlertsWithParams(params)
 }
 
-// FindWithClosedAlertsByNextID find open and close alerts by next id
+// FindWithClosedAlertsByNextID finds open and close alerts by next id.
 func (c *Client) FindWithClosedAlertsByNextID(nextID string) (*AlertsResp, error) {
-	v := url.Values{}
-	v.Set("nextId", nextID)
-	v.Set("withClosed", "true")
-	return c.findAlertsWithParam(v)
+	params := url.Values{}
+	params.Set("nextId", nextID)
+	params.Set("withClosed", "true")
+	return c.findAlertsWithParams(params)
 }
 
-// GetAlert gets Alert
+// GetAlert gets an alert.
 func (c *Client) GetAlert(alertID string) (*Alert, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/alerts/%s", alertID)).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var alert *Alert
-	err = json.NewDecoder(resp.Body).Decode(&alert)
-	if err != nil {
-		return nil, err
-	}
-	return alert, err
+	path := fmt.Sprintf("/api/v0/alerts/%s", alertID)
+	return requestGet[Alert](c, path)
 }
 
-// CloseAlert close alert
+// CloseAlert closes an alert.
 func (c *Client) CloseAlert(alertID string, reason string) (*Alert, error) {
-	var reqBody struct {
-		Reason string `json:"reason"`
-	}
-	reqBody.Reason = reason
-	resp, err := c.PostJSON(fmt.Sprintf("/api/v0/alerts/%s/close", alertID), &reqBody)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data *Alert
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	path := fmt.Sprintf("/api/v0/alerts/%s/close", alertID)
+	return requestPost[Alert](c, path, map[string]string{"reason": reason})
 }
 
-// UpdateAlert updates an Alert
+// UpdateAlert updates an alert.
 func (c *Client) UpdateAlert(alertID string, param UpdateAlertParam) (*UpdateAlertResponse, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/alerts/%s", alertID), param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data UpdateAlertResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data, nil
+	path := fmt.Sprintf("/api/v0/alerts/%s", alertID)
+	return requestPut[UpdateAlertResponse](c, path, param)
 }

--- a/aws_integrations.go
+++ b/aws_integrations.go
@@ -1,12 +1,8 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
-// AWSIntegration aws integration information
+// AWSIntegration AWS integration information
 type AWSIntegration struct {
 	ID           string                            `json:"id"`
 	Name         string                            `json:"name"`
@@ -45,143 +41,55 @@ type CreateAWSIntegrationParam struct {
 // UpdateAWSIntegrationParam parameters for UpdateAwsIntegration
 type UpdateAWSIntegrationParam CreateAWSIntegrationParam
 
-// ListAWSIntegrationExcludableMetrics List of excludeable metric names for aws integration
+// ListAWSIntegrationExcludableMetrics List of excludeable metric names for AWS integration
 type ListAWSIntegrationExcludableMetrics map[string][]string
 
-// FindAWSIntegrations finds AWS Integration Settings
+// FindAWSIntegrations finds AWS integration settings.
 func (c *Client) FindAWSIntegrations() ([]*AWSIntegration, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/aws-integrations").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		AWSIntegrations []*AWSIntegration `json:"aws_integrations"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/aws-integrations")
 	if err != nil {
 		return nil, err
 	}
-	return data.AWSIntegrations, err
+	return data.AWSIntegrations, nil
 }
 
-// FindAWSIntegration finds AWS Integration Setting
-func (c *Client) FindAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var awsIntegration *AWSIntegration
-	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
-	if err != nil {
-		return nil, err
-	}
-	return awsIntegration, err
-}
-
-// CreateAWSIntegration creates AWS Integration Setting
+// CreateAWSIntegration creates an AWS integration setting.
 func (c *Client) CreateAWSIntegration(param *CreateAWSIntegrationParam) (*AWSIntegration, error) {
-	resp, err := c.PostJSON("/api/v0/aws-integrations", param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var awsIntegration *AWSIntegration
-	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
-	if err != nil {
-		return nil, err
-	}
-	return awsIntegration, err
+	return requestPost[AWSIntegration](c, "/api/v0/aws-integrations", param)
 }
 
-// UpdateAWSIntegration updates AWS Integration Setting
+// FindAWSIntegration finds an AWS integration setting.
+func (c *Client) FindAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
+	path := fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)
+	return requestGet[AWSIntegration](c, path)
+}
+
+// UpdateAWSIntegration updates an AWS integration setting.
 func (c *Client) UpdateAWSIntegration(awsIntegrationID string, param *UpdateAWSIntegrationParam) (*AWSIntegration, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID), param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var awsIntegration *AWSIntegration
-	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
-	if err != nil {
-		return nil, err
-	}
-	return awsIntegration, err
+	path := fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)
+	return requestPut[AWSIntegration](c, path, param)
 }
 
-// DeleteAWSIntegration deletes AWS Integration Setting
+// DeleteAWSIntegration deletes an AWS integration setting.
 func (c *Client) DeleteAWSIntegration(awsIntegrationID string) (*AWSIntegration, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var awsIntegration *AWSIntegration
-	err = json.NewDecoder(resp.Body).Decode(&awsIntegration)
-	if err != nil {
-		return nil, err
-	}
-	return awsIntegration, err
+	path := fmt.Sprintf("/api/v0/aws-integrations/%s", awsIntegrationID)
+	return requestDelete[AWSIntegration](c, path)
 }
 
-// CreateAWSIntegrationExternalID creates AWS Integration External ID
+// CreateAWSIntegrationExternalID creates an AWS integration External ID.
 func (c *Client) CreateAWSIntegrationExternalID() (string, error) {
-	resp, err := c.PostJSON("/api/v0/aws-integrations-external-id", nil)
-	defer closeResponse(resp)
-	if err != nil {
-		return "", err
-	}
-
-	var data struct {
+	data, err := requestPost[struct {
 		ExternalID string `json:"externalId"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/aws-integrations-external-id", nil)
 	if err != nil {
 		return "", err
 	}
 	return data.ExternalID, nil
 }
 
-// ListAWSIntegrationExcludableMetrics lists excludable metrics for AWS Integration
+// ListAWSIntegrationExcludableMetrics lists excludable metrics for AWS integration.
 func (c *Client) ListAWSIntegrationExcludableMetrics() (*ListAWSIntegrationExcludableMetrics, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/aws-integrations-excludable-metrics").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var listAWSIntegrationExcludableMetrics *ListAWSIntegrationExcludableMetrics
-	err = json.NewDecoder(resp.Body).Decode(&listAWSIntegrationExcludableMetrics)
-	if err != nil {
-		return nil, err
-	}
-	return listAWSIntegrationExcludableMetrics, err
+	return requestGet[ListAWSIntegrationExcludableMetrics](c, "/api/v0/aws-integrations-excludable-metrics")
 }

--- a/checks.go
+++ b/checks.go
@@ -61,9 +61,8 @@ type CheckReports struct {
 	Reports []*CheckReport `json:"reports"`
 }
 
-// PostCheckReports reports check monitoring results
-func (c *Client) PostCheckReports(crs *CheckReports) error {
-	resp, err := c.PostJSON("/api/v0/monitoring/checks/report", crs)
-	defer closeResponse(resp)
+// PostCheckReports reports check monitoring results.
+func (c *Client) PostCheckReports(checkReports *CheckReports) error {
+	_, err := requestPost[any](c, "/api/v0/monitoring/checks/report", checkReports)
 	return err
 }

--- a/downtimes.go
+++ b/downtimes.go
@@ -3,7 +3,6 @@ package mackerel
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -128,83 +127,30 @@ func (w DowntimeWeekday) String() string {
 	return weekdayToString[w]
 }
 
-// FindDowntimes finds downtimes
+// FindDowntimes finds downtimes.
 func (c *Client) FindDowntimes() ([]*Downtime, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/downtimes").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Downtimes []*Downtime `json:"downtimes"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/downtimes")
 	if err != nil {
 		return nil, err
 	}
-
-	return data.Downtimes, err
+	return data.Downtimes, nil
 }
 
-// CreateDowntime creates a downtime
+// CreateDowntime creates a downtime.
 func (c *Client) CreateDowntime(param *Downtime) (*Downtime, error) {
-	resp, err := c.PostJSON("/api/v0/downtimes", param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data Downtime
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
+	return requestPost[Downtime](c, "/api/v0/downtimes", param)
 }
 
-// UpdateDowntime updates a downtime
+// UpdateDowntime updates a downtime.
 func (c *Client) UpdateDowntime(downtimeID string, param *Downtime) (*Downtime, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/downtimes/%s", downtimeID), param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data Downtime
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
+	path := fmt.Sprintf("/api/v0/downtimes/%s", downtimeID)
+	return requestPut[Downtime](c, path, param)
 }
 
-// DeleteDowntime deletes downtime
+// DeleteDowntime deletes a downtime.
 func (c *Client) DeleteDowntime(downtimeID string) (*Downtime, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/downtimes/%s", downtimeID)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data Downtime
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
+	path := fmt.Sprintf("/api/v0/downtimes/%s", downtimeID)
+	return requestDelete[Downtime](c, path)
 }

--- a/graph_annotation.go
+++ b/graph_annotation.go
@@ -1,14 +1,12 @@
 package mackerel
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 )
 
-// GraphAnnotation represents parameters to post graph annotation.
+// GraphAnnotation represents parameters to post a graph annotation.
 type GraphAnnotation struct {
 	ID          string   `json:"id,omitempty"`
 	Title       string   `json:"title,omitempty"`
@@ -19,90 +17,35 @@ type GraphAnnotation struct {
 	Roles       []string `json:"roles,omitempty"`
 }
 
-// CreateGraphAnnotation creates graph annotation.
+// FindGraphAnnotations fetches graph annotations.
+func (c *Client) FindGraphAnnotations(service string, from int64, to int64) ([]*GraphAnnotation, error) {
+	params := url.Values{}
+	params.Add("service", service)
+	params.Add("from", strconv.FormatInt(from, 10))
+	params.Add("to", strconv.FormatInt(to, 10))
+
+	data, err := requestGetWithParams[struct {
+		GraphAnnotations []*GraphAnnotation `json:"graphAnnotations"`
+	}](c, "/api/v0/graph-annotations", params)
+	if err != nil {
+		return nil, err
+	}
+	return data.GraphAnnotations, nil
+}
+
+// CreateGraphAnnotation creates a graph annotation.
 func (c *Client) CreateGraphAnnotation(annotation *GraphAnnotation) (*GraphAnnotation, error) {
-	resp, err := c.PostJSON("/api/v0/graph-annotations", annotation)
-	defer closeResponse(resp)
-
-	if err != nil {
-		return nil, err
-	}
-
-	var anno GraphAnnotation
-	err = json.NewDecoder(resp.Body).Decode(&anno)
-	if err != nil {
-		return nil, err
-	}
-	return &anno, nil
+	return requestPost[GraphAnnotation](c, "/api/v0/graph-annotations", annotation)
 }
 
-// FindGraphAnnotations fetches graph annotation.
-func (c *Client) FindGraphAnnotations(service string, from int64, to int64) ([]GraphAnnotation, error) {
-	v := url.Values{}
-	v.Add("service", service)
-	v.Add("from", strconv.FormatInt(from, 10))
-	v.Add("to", strconv.FormatInt(to, 10))
-
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", c.urlFor("/api/v0/graph-annotations").String(), v.Encode()), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
-		GraphAnnotations []GraphAnnotation `json:"graphAnnotations"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return data.GraphAnnotations, err
-}
-
-// UpdateGraphAnnotation updates graph annotation.
+// UpdateGraphAnnotation updates a graph annotation.
 func (c *Client) UpdateGraphAnnotation(annotationID string, annotation *GraphAnnotation) (*GraphAnnotation, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/graph-annotations/%s", annotationID), annotation)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var updatedAnnotation = GraphAnnotation{}
-	err = json.NewDecoder(resp.Body).Decode(&updatedAnnotation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &updatedAnnotation, nil
+	path := fmt.Sprintf("/api/v0/graph-annotations/%s", annotationID)
+	return requestPut[GraphAnnotation](c, path, annotation)
 }
 
-// DeleteGraphAnnotation deletes graph annotation.
+// DeleteGraphAnnotation deletes a graph annotation.
 func (c *Client) DeleteGraphAnnotation(annotationID string) (*GraphAnnotation, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/graph-annotations/%s", annotationID)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var annotation GraphAnnotation
-	err = json.NewDecoder(resp.Body).Decode(&annotation)
-	if err != nil {
-		return nil, err
-	}
-	return &annotation, nil
+	path := fmt.Sprintf("/api/v0/graph-annotations/%s", annotationID)
+	return requestDelete[GraphAnnotation](c, path)
 }

--- a/graph_defs.go
+++ b/graph_defs.go
@@ -15,9 +15,8 @@ type GraphDefsMetric struct {
 	IsStacked   bool   `json:"isStacked"`
 }
 
-// CreateGraphDefs create graph defs
-func (c *Client) CreateGraphDefs(payloads []*GraphDefsParam) error {
-	resp, err := c.PostJSON("/api/v0/graph-defs/create", payloads)
-	defer closeResponse(resp)
+// CreateGraphDefs creates graph definitions.
+func (c *Client) CreateGraphDefs(graphDefs []*GraphDefsParam) error {
+	_, err := requestPost[any](c, "/api/v0/graph-defs/create", graphDefs)
 	return err
 }

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -152,8 +152,8 @@ func TestFindHosts(t *testing.T) {
 
 func TestFindHostByCustomIdentifier(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		if req.URL.RawPath != "/api/v0/hosts-by-custom-identifier/mydb001%2F001" {
-			t.Error("request URL.RawPath should be /api/v0/hosts-by-custom-identifier/mydb001%$2F001 but: ", req.URL.RawPath)
+		if req.URL.Path != "/api/v0/hosts-by-custom-identifier/mydb001%2F001" {
+			t.Error("request URL.Path should be /api/v0/hosts-by-custom-identifier/mydb001%$2F001 but: ", req.URL.Path)
 		}
 
 		query := req.URL.Query()

--- a/invitations.go
+++ b/invitations.go
@@ -1,10 +1,5 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"net/http"
-)
-
 // Invitation information
 type Invitation struct {
 	Email     string `json:"email,omitempty"`
@@ -12,25 +7,13 @@ type Invitation struct {
 	ExpiresAt int64  `json:"expiresAt,omitempty"`
 }
 
-// FindInvitations find invitations.
+// FindInvitations finds invitations.
 func (c *Client) FindInvitations() ([]*Invitation, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/invitations").String(), nil)
-
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Invitations []*Invitation `json:"invitations"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/invitations")
 	if err != nil {
 		return nil, err
 	}
-	return data.Invitations, err
+	return data.Invitations, nil
 }

--- a/notification_groups.go
+++ b/notification_groups.go
@@ -1,10 +1,6 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
 // NotificationLevel represents a level of notification.
 type NotificationLevel string
@@ -38,82 +34,30 @@ type NotificationGroupService struct {
 	Name string `json:"name"`
 }
 
-// CreateNotificationGroup creates a notification group.
-func (c *Client) CreateNotificationGroup(param *NotificationGroup) (*NotificationGroup, error) {
-	resp, err := c.PostJSON("/api/v0/notification-groups", param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var notificationGroup NotificationGroup
-	if err := json.NewDecoder(resp.Body).Decode(&notificationGroup); err != nil {
-		return nil, err
-	}
-
-	return &notificationGroup, nil
-}
-
-// FindNotificationGroups finds notification groups
+// FindNotificationGroups finds notification groups.
 func (c *Client) FindNotificationGroups() ([]*NotificationGroup, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/notification-groups").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		NotificationGroups []*NotificationGroup `json:"notificationGroups"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+	}](c, "/api/v0/notification-groups")
+	if err != nil {
 		return nil, err
 	}
-
 	return data.NotificationGroups, nil
 }
 
-// UpdateNotificationGroup updates a notification group
-func (c *Client) UpdateNotificationGroup(id string, param *NotificationGroup) (*NotificationGroup, error) {
-	resp, err := c.PutJSON(fmt.Sprintf("/api/v0/notification-groups/%s", id), param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var notificationGroup NotificationGroup
-	if err := json.NewDecoder(resp.Body).Decode(&notificationGroup); err != nil {
-		return nil, err
-	}
-
-	return &notificationGroup, nil
+// CreateNotificationGroup creates a notification group.
+func (c *Client) CreateNotificationGroup(param *NotificationGroup) (*NotificationGroup, error) {
+	return requestPost[NotificationGroup](c, "/api/v0/notification-groups", param)
 }
 
-// DeleteNotificationGroup deletes a notification group
+// UpdateNotificationGroup updates a notification group.
+func (c *Client) UpdateNotificationGroup(id string, param *NotificationGroup) (*NotificationGroup, error) {
+	path := fmt.Sprintf("/api/v0/notification-groups/%s", id)
+	return requestPut[NotificationGroup](c, path, param)
+}
+
+// DeleteNotificationGroup deletes a notification group.
 func (c *Client) DeleteNotificationGroup(id string) (*NotificationGroup, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/notification-groups/%s", id)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var notificationGroup NotificationGroup
-	if err := json.NewDecoder(resp.Body).Decode(&notificationGroup); err != nil {
-		return nil, err
-	}
-	return &notificationGroup, nil
+	path := fmt.Sprintf("/api/v0/notification-groups/%s", id)
+	return requestDelete[NotificationGroup](c, path)
 }

--- a/org.go
+++ b/org.go
@@ -1,30 +1,11 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"net/http"
-)
-
 // Org information
 type Org struct {
 	Name string `json:"name"`
 }
 
-// GetOrg get the org
+// GetOrg gets the org.
 func (c *Client) GetOrg() (*Org, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/org").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	var data Org
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
+	return requestGet[Org](c, "/api/v0/org")
 }

--- a/roles.go
+++ b/roles.go
@@ -1,10 +1,6 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
 // Role represents Mackerel "role".
 type Role struct {
@@ -17,66 +13,23 @@ type CreateRoleParam Role
 
 // FindRoles finds roles.
 func (c *Client) FindRoles(serviceName string) ([]*Role, error) {
-	uri := fmt.Sprintf("/api/v0/services/%s/roles", serviceName)
-	req, err := http.NewRequest("GET", c.urlFor(uri).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Roles []*Role `json:"roles"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, fmt.Sprintf("/api/v0/services/%s/roles", serviceName))
 	if err != nil {
 		return nil, err
 	}
-	return data.Roles, err
+	return data.Roles, nil
 }
 
-// CreateRole creates role.
+// CreateRole creates a role.
 func (c *Client) CreateRole(serviceName string, param *CreateRoleParam) (*Role, error) {
-	uri := fmt.Sprintf("/api/v0/services/%s/roles", serviceName)
-	resp, err := c.PostJSON(uri, param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	role := &Role{}
-	err = json.NewDecoder(resp.Body).Decode(role)
-	if err != nil {
-		return nil, err
-	}
-	return role, nil
+	path := fmt.Sprintf("/api/v0/services/%s/roles", serviceName)
+	return requestPost[Role](c, path, param)
 }
 
-// DeleteRole deletes role.
+// DeleteRole deletes a role.
 func (c *Client) DeleteRole(serviceName, roleName string) (*Role, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/services/%s/roles/%s", serviceName, roleName)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	role := &Role{}
-	err = json.NewDecoder(resp.Body).Decode(role)
-	if err != nil {
-		return nil, err
-	}
-	return role, nil
+	path := fmt.Sprintf("/api/v0/services/%s/roles/%s", serviceName, roleName)
+	return requestDelete[Role](c, path)
 }

--- a/services.go
+++ b/services.go
@@ -1,10 +1,6 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
 // Service represents Mackerel "service".
 type Service struct {
@@ -21,86 +17,33 @@ type CreateServiceParam struct {
 
 // FindServices finds services.
 func (c *Client) FindServices() ([]*Service, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/services").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Services []*Service `json:"services"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/services")
 	if err != nil {
 		return nil, err
 	}
-	return data.Services, err
+	return data.Services, nil
 }
 
-// CreateService creates service
+// CreateService creates a service.
 func (c *Client) CreateService(param *CreateServiceParam) (*Service, error) {
-	resp, err := c.PostJSON("/api/v0/services", param)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	service := &Service{}
-	err = json.NewDecoder(resp.Body).Decode(service)
-	if err != nil {
-		return nil, err
-	}
-	return service, nil
+	return requestPost[Service](c, "/api/v0/services", param)
 }
 
-// DeleteService deletes service
+// DeleteService deletes a service.
 func (c *Client) DeleteService(serviceName string) (*Service, error) {
-	req, err := http.NewRequest(
-		"DELETE",
-		c.urlFor(fmt.Sprintf("/api/v0/services/%s", serviceName)).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	service := &Service{}
-	err = json.NewDecoder(resp.Body).Decode(service)
-	if err != nil {
-		return nil, err
-	}
-	return service, nil
+	path := fmt.Sprintf("/api/v0/services/%s", serviceName)
+	return requestDelete[Service](c, path)
 }
 
-// ListServiceMetricNames lists metric names of a service
+// ListServiceMetricNames lists metric names of a service.
 func (c *Client) ListServiceMetricNames(serviceName string) ([]string, error) {
-	req, err := http.NewRequest("GET", c.urlFor(fmt.Sprintf("/api/v0/services/%s/metric-names", serviceName)).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Names []string `json:"names"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, fmt.Sprintf("/api/v0/services/%s/metric-names", serviceName))
 	if err != nil {
 		return nil, err
 	}
-	return data.Names, err
+	return data.Names, nil
 }

--- a/users.go
+++ b/users.go
@@ -1,10 +1,6 @@
 package mackerel
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-)
+import "fmt"
 
 // User information
 type User struct {
@@ -19,46 +15,19 @@ type User struct {
 	JoinedAt                int64    `json:"joinedAt,omitempty"`
 }
 
-// FindUsers find users.
+// FindUsers finds users.
 func (c *Client) FindUsers() ([]*User, error) {
-	req, err := http.NewRequest("GET", c.urlFor("/api/v0/users").String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	var data struct {
+	data, err := requestGet[struct {
 		Users []*User `json:"users"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	}](c, "/api/v0/users")
 	if err != nil {
 		return nil, err
 	}
-	return data.Users, err
+	return data.Users, nil
 }
 
-// DeleteUser delete users.
+// DeleteUser deletes a user.
 func (c *Client) DeleteUser(userID string) (*User, error) {
-	req, err := http.NewRequest("DELETE", c.urlFor(fmt.Sprintf("/api/v0/users/%s", userID)).String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := c.Request(req)
-	defer closeResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	user := &User{}
-	err = json.NewDecoder(resp.Body).Decode(user)
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
+	path := fmt.Sprintf("/api/v0/users/%s", userID)
+	return requestDelete[User](c, path)
 }


### PR DESCRIPTION
I noticed a REST API is not implemented in this official client (can you tell which one?). I was to implement to support the API, but I noticed that there are too many code duplication. Most client methods create a http request, serialize the payload and add content type header, send the request, and decode the response body. Some methods use `c.PostJSON(...)`, but this does not support decoding response bodies.

_Too much code duplication makes it boring to read and write._

One of the difficulties to deduplicate this kind of client code _was_ how to decode the response body into each type. But Generics was out in Go 1.18 and it changed the world of Go. We can now use Generics in this library, [you now support only Go 1.20 and 1.21](https://github.com/mackerelio/workflows/blob/bc11d67e72982bd59ae7e544c65f101b3231ca13/.github/workflows/setup-go-matrix.yml#L16). One of the unfamous limitation of it is that we cannot use it for struct methods, but I think this is a small thing, just pass the receiver as an argument.

Here's a list of client utilities I implemented in this PR. There are four requestX each method, and two variants for GET.
```go
func requestGet[T any](client *Client, path string) (*T, error)
func requestGetWithParams[T any](client *Client, path string, params url.Values) (*T, error)
func requestGetAndReturnHeader[T any](client *Client, path string) (*T, http.Header, error)
func requestPost[T any](client *Client, path string, payload any) (*T, error)
func requestPut[T any](client *Client, path string, payload any) (*T, error)
func requestDelete[T any](client *Client, path string) (*T, error)
```

For example, we can implement some methods using the utilities as follows.
```go
func (c *Client) GetOrg() (*Org, error) {
	return requestGet[Org](c, "/api/v0/org")
}

func (c *Client) CreateDowntime(param *Downtime) (*Downtime, error) {
	return requestPost[Downtime](c, "/api/v0/downtimes", param)
}

func (c *Client) FindServices() ([]*Service, error) {
	data, err := requestGet[struct {
		Services []*Service `json:"services"`
	}](c, "/api/v0/services")
	if err != nil {
		return nil, err
	}
	return data.Services, nil
}

func (c *Client) FetchLatestMetricValues(hostIDs []string, metricNames []string) (LatestMetricValues, error) {
	params := url.Values{}
	for _, hostID := range hostIDs {
		params.Add("hostId", hostID)
	}
	for _, metricName := range metricNames {
		params.Add("name", metricName)
	}

	data, err := requestGetWithParams[struct {
		LatestMetricValues LatestMetricValues `json:"tsdbLatest"`
	}](c, "/api/v0/tsdb/latest", params)
	if err != nil {
		return nil, err
	}
	return data.LatestMetricValues, nil
}
```

This is more declarative and neat isn't it? We don't need to care about closing the response, to duplicate code decoding the response body. Previously the code was like this...

```go
func (c *Client) GetOrg() (*Org, error) {
	req, err := http.NewRequest("GET", c.urlFor("/api/v0/org").String(), nil)
	if err != nil {
		return nil, err
	}
	resp, err := c.Request(req)
	defer closeResponse(resp)
	if err != nil {
		return nil, err
	}
	var data Org
	err = json.NewDecoder(resp.Body).Decode(&data)
	if err != nil {
		return nil, err
	}
	return &data, nil
}

func (c *Client) CreateDowntime(param *Downtime) (*Downtime, error) {
	resp, err := c.PostJSON("/api/v0/downtimes", param)
	defer closeResponse(resp)
	if err != nil {
		return nil, err
	}

	var data Downtime
	err = json.NewDecoder(resp.Body).Decode(&data)
	if err != nil {
		return nil, err
	}
	return &data, nil
}

func (c *Client) FindServices() ([]*Service, error) {
	req, err := http.NewRequest("GET", c.urlFor("/api/v0/services").String(), nil)
	if err != nil {
		return nil, err
	}
	resp, err := c.Request(req)
	defer closeResponse(resp)
	if err != nil {
		return nil, err
	}

	var data struct {
		Services []*Service `json:"services"`
	}
	err = json.NewDecoder(resp.Body).Decode(&data)
	if err != nil {
		return nil, err
	}
	return data.Services, err
}

func (c *Client) FetchLatestMetricValues(hostIDs []string, metricNames []string) (LatestMetricValues, error) {
	v := url.Values{}
	for _, hostID := range hostIDs {
		v.Add("hostId", hostID)
	}
	for _, metricName := range metricNames {
		v.Add("name", metricName)
	}

	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", c.urlFor("/api/v0/tsdb/latest").String(), v.Encode()), nil)
	if err != nil {
		return nil, err
	}
	resp, err := c.Request(req)
	defer closeResponse(resp)
	if err != nil {
		return nil, err
	}

	var data struct {
		LatestMetricValues LatestMetricValues `json:"tsdbLatest"`
	}
	err = json.NewDecoder(resp.Body).Decode(&data)
	if err != nil {
		return nil, err
	}

	return data.LatestMetricValues, err
}
```

My only concern is how this patch grows end users' executable file size. I tested only `mkr`, but file size growth is small (linux amd64 executable size: 10572K -> 10640K). I think this is acceptable, but if there's a case suffering from this patch, we can drop the type parameter from `requestInternal`, create the response value in `requestGet`, etc., and pass it by reference. This reduces the generated code for `requestInternal`.

I'm sorry for submitting a large refactoring patch. I don't mind you close this PR due to any reason, because I don't care how much code it is implemented by, as a package user. But hopefully, I would like to see some good news.

---

This is an off topic. I'm maintaining [mackerel-client-rs](https://github.com/itchyny/mackerel-client-rs). After two years of hiatus, I rebooted the implementation recently. Due to the richness of type system and my own macro definition, I can implement the client methods with fancy code. This leads me motivated to reduce the code duplication of the Go client.

<details><summary>Example of mackerel-client-rs code</summary>

```rust
pub async fn get_organization(&self) -> Result<Organization> {
    self.request(
        Method::GET,
        "/api/v0/org",
        query_params![],
        request_body![],
        response_body!(..),
    )
    .await
}

pub async fn create_downtime(&self, downtime_value: &DowntimeValue) -> Result<Downtime> {
    self.request(
        Method::POST,
        "/api/v0/downtimes",
        query_params![],
        request_body!(downtime_value),
        response_body!(..),
    )
    .await
}

pub async fn list_services(&self) -> Result<Vec<Service>> {
    self.request(
        Method::GET,
        "/api/v0/services",
        query_params![],
        request_body![],
        response_body! { services: Vec<Service> },
    )
    .await
}

pub async fn list_latest_host_metric_values(
    &self,
    host_ids: impl IntoIterator<Item = impl Into<HostId>>,
    metric_names: impl IntoIterator<Item = impl AsRef<str>>,
) -> Result<HashMap<HostId, HashMap<String, Option<MetricValue>>>> {
    self.request(
        Method::GET,
        "/api/v0/tsdb/latest",
        &host_ids
            .into_iter()
            .map(|host_id| ("hostId", host_id.into().to_string()))
            .chain(
                metric_names
                    .into_iter()
                    .map(|metric_name| ("name", metric_name.as_ref().to_owned())),
            )
            .collect::<Vec<_>>(),
        request_body![],
        response_body! { tsdbLatest: HashMap<HostId, HashMap<String, Option<MetricValue>>> },
    )
    .await
}
```
</details>
