### PR TITLE
Always add `Content-Type` header for non GET APIs

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -174,7 +174,7 @@ func requestInternal[T any](client *Client, method, path string, params url.Valu
 	if err != nil {
 		return nil, nil, err
 	}
-	if body != nil || method != "GET" {
+	if body != nil || method != http.MethodGet {
 		req.Header.Add("Content-Type", "application/json")
 	}
 

--- a/mackerel.go
+++ b/mackerel.go
@@ -131,27 +131,27 @@ func (c *Client) Request(req *http.Request) (resp *http.Response, err error) {
 }
 
 func requestGet[T any](client *Client, path string) (*T, error) {
-	return requestNoBody[T](client, "GET", path, nil)
+	return requestNoBody[T](client, http.MethodGet, path, nil)
 }
 
 func requestGetWithParams[T any](client *Client, path string, params url.Values) (*T, error) {
-	return requestNoBody[T](client, "GET", path, params)
+	return requestNoBody[T](client, http.MethodGet, path, params)
 }
 
 func requestGetAndReturnHeader[T any](client *Client, path string) (*T, http.Header, error) {
-	return requestInternal[T](client, "GET", path, nil, nil)
+	return requestInternal[T](client, http.MethodGet, path, nil, nil)
 }
 
 func requestPost[T any](client *Client, path string, payload any) (*T, error) {
-	return requestJSON[T](client, "POST", path, payload)
+	return requestJSON[T](client, http.MethodPost, path, payload)
 }
 
 func requestPut[T any](client *Client, path string, payload any) (*T, error) {
-	return requestJSON[T](client, "PUT", path, payload)
+	return requestJSON[T](client, http.MethodPut, path, payload)
 }
 
 func requestDelete[T any](client *Client, path string) (*T, error) {
-	return requestNoBody[T](client, "DELETE", path, nil)
+	return requestNoBody[T](client, http.MethodDelete, path, nil)
 }
 
 func requestJSON[T any](client *Client, method, path string, payload any) (*T, error) {

--- a/mackerel.go
+++ b/mackerel.go
@@ -174,7 +174,7 @@ func requestInternal[T any](client *Client, method, path string, params url.Valu
 	if err != nil {
 		return nil, nil, err
 	}
-	if body != nil {
+	if body != nil || method != "GET" {
 		req.Header.Add("Content-Type", "application/json")
 	}
 

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -58,7 +58,7 @@ func Test_requestInternal(t *testing.T) {
 				if test.hasContentTypeHeader && req.Header.Get("Content-Type") != "application/json" {
 					t.Error("Content-Type header should have application/json")
 				}
-				res.Write([]byte(`{"success": true}`))
+				res.Write([]byte(`{"success": true}`)) // nolint
 			}))
 			defer ts.Close()
 

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -51,6 +51,7 @@ func Test_requestInternal(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s with %v body", test.method, test.body), func(tt *testing.T) {
+			// Test server that make requests consistent with Mackerel behavior
 			ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 				if !test.hasContentTypeHeader && req.Header.Get("Content-Type") == "application/json" {
 					t.Error("Content-Type header should not have application/json")

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -40,14 +40,14 @@ func Test_requestInternal(t *testing.T) {
 		body                 io.Reader
 		hasContentTypeHeader bool
 	}{
-		{"GET", nil, false},
-		{"POST", nil, true},
-		{"PUT", nil, true},
-		{"DELETE", nil, true},
-		{"GET", strings.NewReader("some"), true},
-		{"POST", strings.NewReader("some"), true},
-		{"PUT", strings.NewReader("some"), true},
-		{"DELETE", strings.NewReader("some"), true},
+		{http.MethodGet, nil, false},
+		{http.MethodPost, nil, true},
+		{http.MethodPut, nil, true},
+		{http.MethodDelete, nil, true},
+		{http.MethodGet, strings.NewReader("some"), true},
+		{http.MethodPost, strings.NewReader("some"), true},
+		{http.MethodPut, strings.NewReader("some"), true},
+		{http.MethodDelete, strings.NewReader("some"), true},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s with %v body", test.method, test.body), func(tt *testing.T) {


### PR DESCRIPTION
It seems that non GET APIs must always have Content-Type: application/json request header even though they don't require request body.

For example,

```console
% curl https://api.mackerelio.com/api/v0/aws-integrations-external-id -X POST -H "X-Api-Key: ..."
{"error":{"message":"Illegal Content-Type. Please try with \"Content-Type: application/json\""}}

% curl https://api.mackerelio.com/api/v0/channels/XXX -X DELETE -H "X-Api-Key: ..."
{"error":{"message":"Illegal Content-Type. Please try with \"Content-Type: application/json\""}}
```

But recent changes stop sending them and got errors like `error API request failed: Illegal Content-Type. Please try with "Content-Type: application/json"`.