### PR TITLE
Add new monitor for Labeled Metric

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -93,10 +93,10 @@ import (
       "name": "LabeldMetric - custom.access_counter",
       "query": "custom.access_counter",
       "operator": ">",
-	  "warning": 30.0,
-	  "critical": 300.0,
-	  "legend":""
-	}
+      "warning": 30.0,
+      "critical": 300.0,
+      "legend":""
+    }
   ]
 }
 */

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -772,6 +772,30 @@ var testCases = []struct {
 			"notificationInterval": 60
 		}`,
 	},
+	{
+		"query monitor",
+		&MonitorQuery{
+			ID:                   "2cSZzK3XfmI",
+			Name:                 "query monitor",
+			Type:                 "query",
+			IsMute:               false,
+			NotificationInterval: 60,
+			Query:                "custom.counter",
+			Operator:             ">",
+			Warning:              pfloat64(10.0),
+			Critical:             nil,
+		},
+		`{
+			"id"  : "2cSZzK3XfmI",
+			"type": "query",
+			"name": "query monitor",
+			"query": "custom.counter",
+			"operator": ">",
+			"warning": 10.0,
+			"critical": null,
+			"notificationInterval": 60
+		}`,
+	},
 }
 
 func TestDecodeEncodeMonitor(t *testing.T) {


### PR DESCRIPTION
In the current version, an error occurs when running the code below.
```go 
package main

import (
	"errors"
	"log"
	"os"

	"github.com/mackerelio/mackerel-client-go"
)

func main() {
	client := mackerel.NewClient(os.Getenv("MACKEREL_APIKEY"))
	monitor, err := client.GetMonitor(os.Getenv("MONITOR_ID")) // query monitor
	if err != nil {
		var apiError *mackerel.APIError
		if errors.As(err, &apiError) {
			log.Fatalf("API error: %#v", apiError)
		}
		log.Fatalf("%#v", err)
	}
	log.Printf("monitor: %v", monitor)
}
```

```shell
$ go run main.go 
2024/04/02 11:28:56 &mackerel.unknownMonitorTypeError{Type:"query"}
exit status 1
```

When I checked the API with Curl as shown below, it seemed to be able to be obtained successfully.
```shell
$  curl -H "X-Api-Key:$MACKEREL_APIKEY" https://api.mackerelio.com/api/v0/monitors/<monitor_id>
{"monitor":{"critical":300,"isMute":false,"legend":"","query":"test.my_counter","name":"my counter","warning":30,"id":"<monitor_id>","type":"query","operator":">"}}%     
```

Therefore, in this PR, we modified it to be compatible with query monitor.
By applying this PR, the execution result of the code at the beginning will be as follows.
```shell
$ go run main.go 
2024/04/02 11:27:47 monitor: &{<monitor_id> my counter  query false 0 test.my_counter > 0x1400018c4d0 0x1400018c4a8 }
```
