### PR TITLE
Modify URL path of DeleteGraphDef

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/mackerelio/mackerel-client-go
 go 1.18
 
 require github.com/kylelemons/godebug v1.1.0
+
+retract v0.33.0 // API endpoint for DeleteGraphDef has changed.

--- a/graph_defs.go
+++ b/graph_defs.go
@@ -25,6 +25,6 @@ func (c *Client) CreateGraphDefs(graphDefs []*GraphDefsParam) error {
 
 // DeleteGraphDef deletes a graph definition.
 func (c *Client) DeleteGraphDef(name string) error {
-	_, err := requestJSON[any](c, http.MethodDelete, "/api/v0/graph-defs/delete", map[string]string{"name": name})
+	_, err := requestJSON[any](c, http.MethodDelete, "/api/v0/graph-defs", map[string]string{"name": name})
 	return err
 }

--- a/graph_defs_test.go
+++ b/graph_defs_test.go
@@ -102,8 +102,8 @@ func TestGraphDefsOmitJSON(t *testing.T) {
 
 func TestDeleteGraphDef(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/api/v0/graph-defs/delete" {
-			t.Error("request URL should be /api/v0/graph-defs/delete but:", req.URL.Path)
+		if req.URL.Path != "/api/v0/graph-defs" {
+			t.Error("request URL should be /api/v0/graph-defs but:", req.URL.Path)
 		}
 
 		if req.Method != "DELETE" {


### PR DESCRIPTION
Due to discussion in #157, the URL path for DeleteGraphDef (which is a recently created API) was changed from `DELETE /api/v0/graph-defs/delete` to `DELETE /api/v0/graph-defs`.