### PR TITLE
upgrade go 1.18 -> 1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mackerelio/mackerel-client-go
 
-go 1.18
+go 1.21.0
 
 require github.com/kylelemons/godebug v1.1.0
 


### PR DESCRIPTION
Go 1.20 or higher is needed for #160 because it uses context.Cause