### PR TITLE
Fix non-constant format string in call in tests

### DIFF
--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -121,7 +121,7 @@ func TestPrivateTracef(t *testing.T) {
 	defer log.SetFlags(oflags)
 	log.SetFlags(0)
 
-	msg := "test\n"
+	const msg = "test\n"
 	t.Run("Logger+PrioritizedLogger", func(t *testing.T) {
 		var c Client
 		c.Logger = log.New(&logbuf, "", 0)


### PR DESCRIPTION
Go 1.24 will add verification of non-constant format strings.
It runs vet on testing so it fails on the mackerel-client-go tests.
See https://github.com/golang/go/issues/60529.

```
 $ gotip test ./...                      
# github.com/mackerelio/mackerel-client-go
# [github.com/mackerelio/mackerel-client-go]
./mackerel_test.go:129:12: non-constant format string in call to (*github.com/mackerelio/mackerel-client-go.Client).tracef
./mackerel_test.go:147:12: non-constant format string in call to (*github.com/mackerelio/mackerel-client-go.Client).tracef
./mackerel_test.go:165:12: non-constant format string in call to (*github.com/mackerelio/mackerel-client-go.Client).tracef
./mackerel_test.go:182:12: non-constant format string in call to (*github.com/mackerelio/mackerel-client-go.Client).tracef
FAIL    github.com/mackerelio/mackerel-client-go [build failed]
FAIL
```
