### PR TITLE
remove coveralls status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@ mackerel-client-go
 ==================
 
 [![Build Status](https://github.com/mackerelio/mackerel-client-go/workflows/Build/badge.svg?branch=master)][actions]
-[![Coverage Status](https://coveralls.io/repos/mackerelio/mackerel-client-go/badge.svg?branch=master)][coveralls]
 [![pkg.go.dev](https://pkg.go.dev/badge/github.com/mackerelio/mackerel-client-go)][pkg.go.dev]
 
 [actions]: https://github.com/mackerelio/mackerel-client-go/actions?workflow=Build
-[coveralls]: https://coveralls.io/r/mackerelio/mackerel-client-go?branch=master
 [pkg.go.dev]: https://pkg.go.dev/github.com/mackerelio/mackerel-client-go
 
 mackerel-client-go is a Go client library for [mackerel.io API](https://mackerel.io/api-docs/).


### PR DESCRIPTION
We stopped to send code coverage to Coveralls since I was merged #164 so we should remove its badge.