### PR TITLE
add EvaluateBackwardMinutes

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -278,7 +278,7 @@ type MonitorExpression struct {
 	Operator                string   `json:"operator,omitempty"`
 	Warning                 *float64 `json:"warning"`
 	Critical                *float64 `json:"critical"`
-	EvaluateBackwardMinutes uint64   `json:"evaluateBackwardMinutes,omitzero"`
+	EvaluateBackwardMinutes *uint64  `json:"evaluateBackwardMinutes,omitempty"`
 }
 
 // MonitorType returns monitor type.
@@ -330,7 +330,7 @@ type MonitorQuery struct {
 	Warning                 *float64 `json:"warning"`
 	Critical                *float64 `json:"critical"`
 	Legend                  string   `json:"legend,omitempty"`
-	EvaluateBackwardMinutes uint64   `json:"evaluateBackwardMinutes,omitzero"`
+	EvaluateBackwardMinutes *uint64  `json:"evaluateBackwardMinutes,omitempty"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors.go
+++ b/monitors.go
@@ -274,10 +274,11 @@ type MonitorExpression struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Expression string   `json:"expression,omitempty"`
-	Operator   string   `json:"operator,omitempty"`
-	Warning    *float64 `json:"warning"`
-	Critical   *float64 `json:"critical"`
+	Expression              string   `json:"expression,omitempty"`
+	Operator                string   `json:"operator,omitempty"`
+	Warning                 *float64 `json:"warning"`
+	Critical                *float64 `json:"critical"`
+	EvaluateBackwardMinutes uint64   `json:"evaluateBackwardMinutes,omitzero"`
 }
 
 // MonitorType returns monitor type.
@@ -324,11 +325,12 @@ type MonitorQuery struct {
 	IsMute               bool   `json:"isMute,omitempty"`
 	NotificationInterval uint64 `json:"notificationInterval,omitempty"`
 
-	Query    string   `json:"query,omitempty"`
-	Operator string   `json:"operator,omitempty"`
-	Warning  *float64 `json:"warning"`
-	Critical *float64 `json:"critical"`
-	Legend   string   `json:"legend,omitempty"`
+	Query                   string   `json:"query,omitempty"`
+	Operator                string   `json:"operator,omitempty"`
+	Warning                 *float64 `json:"warning"`
+	Critical                *float64 `json:"critical"`
+	Legend                  string   `json:"legend,omitempty"`
+	EvaluateBackwardMinutes uint64   `json:"evaluateBackwardMinutes,omitzero"`
 }
 
 // MonitorType returns monitor type.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -727,15 +727,16 @@ var testCases = []struct {
 	{
 		"expression monitor",
 		&MonitorExpression{
-			ID:                   "2cSZzK3XfmE",
-			Name:                 "role average",
-			Type:                 "expression",
-			IsMute:               false,
-			NotificationInterval: 60,
-			Expression:           "avg(roleSlots(\"server:role\",\"loadavg5\"))",
-			Operator:             ">",
-			Warning:              pfloat64(5.000000),
-			Critical:             pfloat64(10.000000),
+			ID:                      "2cSZzK3XfmE",
+			Name:                    "role average",
+			Type:                    "expression",
+			IsMute:                  false,
+			NotificationInterval:    60,
+			Expression:              "avg(roleSlots(\"server:role\",\"loadavg5\"))",
+			Operator:                ">",
+			Warning:                 pfloat64(5.000000),
+			Critical:                pfloat64(10.000000),
+			EvaluateBackwardMinutes: puint64(3),
 		},
 		`{
 			"id"  : "2cSZzK3XfmE",
@@ -745,7 +746,8 @@ var testCases = []struct {
 			"operator": ">",
 			"warning": 5.0,
 			"critical": 10.0,
-			"notificationInterval": 60
+			"notificationInterval": 60,
+			"evaluateBackwardMinutes": 3
 		}`,
 	},
 	{


### PR DESCRIPTION
We introduced a new optional field `EvaluateBackwardMinutes` in MonitorExpression and MonitorQuery.