### PR TITLE
Fix the path is encoded twice

### DIFF
--- a/mackerel.go
+++ b/mackerel.go
@@ -3,6 +3,7 @@ package mackerel
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -170,7 +171,9 @@ func requestNoBody[T any](client *Client, method, path string, params url.Values
 }
 
 func requestInternal[T any](client *Client, method, path string, params url.Values, body io.Reader) (*T, http.Header, error) {
-	req, err := http.NewRequest(method, client.urlFor(path, params).String(), body)
+	u := client.urlFor(path, params)
+	url := fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.Path, u.RawQuery)
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
`url.URL.String()` encodes its `Path`. So if `requestInternal` arg `path` is already encoded, it will be encoded twice.

Also `http.Request.URL.Path` is decoded value but `http.Request.URL.RawPath` is encoded value.
They should be treated individually.
`RawPath` may be empty when `Path` has no encodable characters.
https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/net/url/url.go;l=366-383