### PR TITLE
Add support for apm DbQueryStatics API

### DIFF
--- a/apm.go
+++ b/apm.go
@@ -81,3 +81,73 @@ func (c *Client) ListHTTPServerStatsContext(ctx context.Context, param *ListHTTP
 
 	return requestGetWithParamsContext[HTTPServerStatsPageConnection](ctx, c, "/api/v0/apm/http-server-stats", params)
 }
+
+// DbQueryStats represents database query statistics
+type DbQueryStats struct {
+	Query            string  `json:"query"`
+	ExecutionCount   int64   `json:"executionCount"`
+	TotalMillis      float64 `json:"totalMillis"`
+	AverageMillis    float64 `json:"averageMillis"`
+	ApproxP95Millis  float64 `json:"approxP95Millis"`
+}
+
+// DbQueryStatsPageConnection represents a paginated response of database query statistics
+type DbQueryStatsPageConnection struct {
+	Results     []*DbQueryStats `json:"results"`
+	HasNextPage bool            `json:"hasNextPage"`
+}
+
+// ListDbQueryStatsParam represents parameters for listing database query statistics
+type ListDbQueryStatsParam struct {
+	ServiceName      string
+	From             int64
+	To               int64
+	ServiceNamespace *string
+	Environment      *string
+	Version          *string
+	Query            *string
+	OrderColumn      *string
+	OrderDirection   *string
+	Page             *int
+	PerPage          *int
+}
+
+// ListDbQueryStats retrieves database query statistics
+func (c *Client) ListDbQueryStats(param *ListDbQueryStatsParam) (*DbQueryStatsPageConnection, error) {
+	return c.ListDbQueryStatsContext(context.Background(), param)
+}
+
+// ListDbQueryStatsContext is like [ListDbQueryStats].
+func (c *Client) ListDbQueryStatsContext(ctx context.Context, param *ListDbQueryStatsParam) (*DbQueryStatsPageConnection, error) {
+	params := url.Values{}
+	params.Set("serviceName", param.ServiceName)
+	params.Set("from", strconv.FormatInt(param.From, 10))
+	params.Set("to", strconv.FormatInt(param.To, 10))
+
+	if param.ServiceNamespace != nil {
+		params.Set("serviceNamespace", *param.ServiceNamespace)
+	}
+	if param.Environment != nil {
+		params.Set("environment", *param.Environment)
+	}
+	if param.Version != nil {
+		params.Set("version", *param.Version)
+	}
+	if param.Query != nil {
+		params.Set("query", *param.Query)
+	}
+	if param.OrderColumn != nil {
+		params.Set("orderColumn", *param.OrderColumn)
+	}
+	if param.OrderDirection != nil {
+		params.Set("orderDirection", *param.OrderDirection)
+	}
+	if param.Page != nil {
+		params.Set("page", strconv.Itoa(*param.Page))
+	}
+	if param.PerPage != nil {
+		params.Set("perPage", strconv.Itoa(*param.PerPage))
+	}
+
+	return requestGetWithParamsContext[DbQueryStatsPageConnection](ctx, c, "/api/v0/apm/db-query-stats", params)
+}

--- a/apm_test.go
+++ b/apm_test.go
@@ -314,3 +314,295 @@ func TestListHTTPServerStatsContextWithCancel(t *testing.T) {
 		t.Error("err should not be nil for canceled context")
 	}
 }
+
+func TestListDbQueryStats(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/apm/db-query-stats" {
+			t.Error("request URL should be /api/v0/apm/db-query-stats but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		query := req.URL.Query()
+		if query.Get("serviceName") != "test-service" {
+			t.Error("request query 'serviceName' param should be test-service but: ", query.Get("serviceName"))
+		}
+		if query.Get("from") != "1234567890" {
+			t.Error("request query 'from' param should be 1234567890 but: ", query.Get("from"))
+		}
+		if query.Get("to") != "1234567900" {
+			t.Error("request query 'to' param should be 1234567900 but: ", query.Get("to"))
+		}
+		if query.Get("orderColumn") != "P95" {
+			t.Error("request query 'orderColumn' param should be P95 but: ", query.Get("orderColumn"))
+		}
+		if query.Get("orderDirection") != "DESC" {
+			t.Error("request query 'orderDirection' param should be DESC but: ", query.Get("orderDirection"))
+		}
+		if query.Get("page") != "1" {
+			t.Error("request query 'page' param should be 1 but: ", query.Get("page"))
+		}
+		if query.Get("perPage") != "20" {
+			t.Error("request query 'perPage' param should be 20 but: ", query.Get("perPage"))
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{
+					"query":          "SELECT * FROM users WHERE id = ?",
+					"executionCount": 1250,
+					"totalMillis":    11262.5,
+					"averageMillis":  9.01,
+					"approxP95Millis": 19.89,
+				},
+				{
+					"query":          "SELECT * FROM posts WHERE user_id = ?",
+					"executionCount": 3500,
+					"totalMillis":    28000.0,
+					"averageMillis":  8.0,
+					"approxP95Millis": 15.5,
+				},
+			},
+			"hasNextPage": false,
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON)) // nolint
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	orderColumn := "P95"
+	orderDirection := "DESC"
+	page := 1
+	perPage := 20
+
+	result, err := client.ListDbQueryStats(&ListDbQueryStatsParam{
+		ServiceName:    "test-service",
+		From:           1234567890,
+		To:             1234567900,
+		OrderColumn:    &orderColumn,
+		OrderDirection: &orderDirection,
+		Page:           &page,
+		PerPage:        &perPage,
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if result.HasNextPage != false {
+		t.Error("hasNextPage should be false but: ", result.HasNextPage)
+	}
+
+	if len(result.Results) != 2 {
+		t.Error("results length should be 2 but: ", len(result.Results))
+	}
+
+	expectedFirst := &DbQueryStats{
+		Query:          "SELECT * FROM users WHERE id = ?",
+		ExecutionCount: 1250,
+		TotalMillis:    11262.5,
+		AverageMillis:  9.01,
+		ApproxP95Millis: 19.89,
+	}
+
+	if !reflect.DeepEqual(result.Results[0], expectedFirst) {
+		t.Errorf("first result should be %v but: %v", expectedFirst, result.Results[0])
+	}
+
+	expectedSecond := &DbQueryStats{
+		Query:          "SELECT * FROM posts WHERE user_id = ?",
+		ExecutionCount: 3500,
+		TotalMillis:    28000.0,
+		AverageMillis:  8.0,
+		ApproxP95Millis: 15.5,
+	}
+
+	if !reflect.DeepEqual(result.Results[1], expectedSecond) {
+		t.Errorf("second result should be %v but: %v", expectedSecond, result.Results[1])
+	}
+}
+
+func TestListDbQueryStatsWithMinimalParams(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/apm/db-query-stats" {
+			t.Error("request URL should be /api/v0/apm/db-query-stats but: ", req.URL.Path)
+		}
+
+		query := req.URL.Query()
+		if query.Get("serviceName") != "minimal-service" {
+			t.Error("request query 'serviceName' param should be minimal-service but: ", query.Get("serviceName"))
+		}
+		if query.Get("from") != "1000000000" {
+			t.Error("request query 'from' param should be 1000000000 but: ", query.Get("from"))
+		}
+		if query.Get("to") != "2000000000" {
+			t.Error("request query 'to' param should be 2000000000 but: ", query.Get("to"))
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"results":     []map[string]interface{}{},
+			"hasNextPage": false,
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON)) // nolint
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	result, err := client.ListDbQueryStats(&ListDbQueryStatsParam{
+		ServiceName: "minimal-service",
+		From:        1000000000,
+		To:          2000000000,
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if result.HasNextPage != false {
+		t.Error("hasNextPage should be false but: ", result.HasNextPage)
+	}
+
+	if len(result.Results) != 0 {
+		t.Error("results length should be 0 but: ", len(result.Results))
+	}
+}
+
+func TestListDbQueryStatsContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/apm/db-query-stats" {
+			t.Error("request URL should be /api/v0/apm/db-query-stats but: ", req.URL.Path)
+		}
+
+		if req.Method != "GET" {
+			t.Error("request method should be GET but: ", req.Method)
+		}
+
+		query := req.URL.Query()
+		if query.Get("serviceName") != "test-service" {
+			t.Error("request query 'serviceName' param should be test-service but: ", query.Get("serviceName"))
+		}
+		if query.Get("from") != "1234567890" {
+			t.Error("request query 'from' param should be 1234567890 but: ", query.Get("from"))
+		}
+		if query.Get("to") != "1234567900" {
+			t.Error("request query 'to' param should be 1234567900 but: ", query.Get("to"))
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{
+					"query":          "SELECT * FROM users WHERE id = ?",
+					"executionCount": 1250,
+					"totalMillis":    11262.5,
+					"averageMillis":  9.01,
+					"approxP95Millis": 19.89,
+				},
+			},
+			"hasNextPage": true,
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON)) // nolint
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	ctx := context.Background()
+	result, err := client.ListDbQueryStatsContext(ctx, &ListDbQueryStatsParam{
+		ServiceName: "test-service",
+		From:        1234567890,
+		To:          1234567900,
+	})
+
+	if err != nil {
+		t.Error("err should be nil but: ", err)
+	}
+
+	if result.HasNextPage != true {
+		t.Error("hasNextPage should be true but: ", result.HasNextPage)
+	}
+
+	if len(result.Results) != 1 {
+		t.Error("results length should be 1 but: ", len(result.Results))
+	}
+
+	expected := &DbQueryStats{
+		Query:          "SELECT * FROM users WHERE id = ?",
+		ExecutionCount: 1250,
+		TotalMillis:    11262.5,
+		AverageMillis:  9.01,
+		ApproxP95Millis: 19.89,
+	}
+
+	if !reflect.DeepEqual(result.Results[0], expected) {
+		t.Errorf("result should be %v but: %v", expected, result.Results[0])
+	}
+}
+
+func TestListDbQueryStatsContextWithTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"results":     []map[string]interface{}{},
+			"hasNextPage": false,
+		})
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON)) // nolint
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := client.ListDbQueryStatsContext(ctx, &ListDbQueryStatsParam{
+		ServiceName: "test-service",
+		From:        1234567890,
+		To:          1234567900,
+	})
+
+	if err == nil {
+		t.Error("err should not be nil for timeout")
+	}
+}
+
+func TestListDbQueryStatsContextWithCancel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		respJSON, _ := json.Marshal(map[string]interface{}{
+			"results":     []map[string]interface{}{},
+			"hasNextPage": false,
+		})
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJSON)) // nolint
+	}))
+	defer ts.Close()
+
+	client, _ := NewClientWithOptions("dummy-key", ts.URL, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.ListDbQueryStatsContext(ctx, &ListDbQueryStatsParam{
+		ServiceName: "test-service",
+		From:        1234567890,
+		To:          1234567900,
+	})
+
+	if err == nil {
+		t.Error("err should not be nil for canceled context")
+	}
+}


### PR DESCRIPTION
I added support for APM HTTP Server Statics API. https://mackerel.io/api-docs/entry/apm#db-query-stats

- Added the `ListDbQueryStats` function and `ListDbQueryStatsContext` function to `apm.go`.