### PR TITLE
Added support for dashboard legend list param

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -110,6 +110,7 @@ type Widget struct {
 	Range          Range           `json:"range,omitempty"`
 	Markdown       string          `json:"markdown,omitempty"`
 	ReferenceLines []ReferenceLine `json:"referenceLines,omitempty"`
+	LegendList     []string        `json:"legendList,omitempty"`
 	// If this field is nil, it will be treated as a two-digit display after the decimal point.
 	FractionSize *int64       `json:"fractionSize,omitempty"`
 	Suffix       string       `json:"suffix,omitempty"`

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -114,6 +114,7 @@ func TestFindDashboard(t *testing.T) {
 								"value": 1.23,
 							},
 						},
+						"legendList": []string{"loadavg.loadavg1", "loadavg.loadavg5"},
 					},
 					{
 						"type":         "value",
@@ -237,6 +238,10 @@ func TestFindDashboard(t *testing.T) {
 
 	if dashboard.Widgets[1].ReferenceLines[0].Value != 1.23 {
 		t.Error("request sends json including widgets.graph.referenceLines.value but:", dashboard)
+	}
+
+	if dashboard.Widgets[1].LegendList[0] != "loadavg.loadavg1" || dashboard.Widgets[1].LegendList[1] != "loadavg.loadavg5" {
+		t.Error("request sends json including widgets.legendList but:", dashboard)
 	}
 
 	// Widget Test : Metric ( && Expression Type)


### PR DESCRIPTION
See: https://mackerel.io/api-docs/entry/dashboards#create:~:text=in%20an%20array.-,legendList,-array%5Bstring%5D

Example:

```go
legendList := []string{"cpu.user.percentage", "cpu.system.percentage"}
client.CreateDashboard(&mackerel.Dashboard{
        Title:   "test",
        URLPath: "test",
        Memo:    "",
        Widgets: []mackerel.Widget{
                {
                        Type:  "graph",
                        Title: "Test Graph with LegendList",
                        Layout: mackerel.Layout{X: 0, Y: 0, Width: 12, Height: 6},
                        Graph: mackerel.Graph{
                                Type:   "host",
                                HostID: "abcde",
                                Name:   "cpu",
                        },
                        LegendList: legendList,
                },
        },
})        
```